### PR TITLE
build: rename modules to jspwiki-knowwe-* at 3.0.0-SNAPSHOT

### DIFF
--- a/jspwiki-210-adapters/pom.xml
+++ b/jspwiki-210-adapters/pom.xml
@@ -21,25 +21,25 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-210-adapters</artifactId>
+  <artifactId>jspwiki-knowwe-210-adapters</artifactId>
   <name>Apache JSPWiki adapters for pre-public api</name>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-210-test-adaptees</artifactId>
+      <artifactId>jspwiki-knowwe-210-test-adaptees</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/jspwiki-210-test-adaptees/pom.xml
+++ b/jspwiki-210-test-adaptees/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-210-test-adaptees</artifactId>
+  <artifactId>jspwiki-knowwe-210-test-adaptees</artifactId>
   <name>Apache JSPWiki test extensions not using public api</name>
   
   <properties>
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>2.11.0.M6</version>
       <scope>provided</scope>
       <exclusions>
@@ -49,7 +49,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <type>test-jar</type>
       <version>2.11.0.M6</version>
       <scope>test</scope>

--- a/jspwiki-api/pom.xml
+++ b/jspwiki-api/pom.xml
@@ -21,24 +21,24 @@
 
     <parent>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-builder</artifactId>
-        <version>3.0.0</version>
+        <artifactId>jspwiki-knowwe-builder</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jspwiki-api</artifactId>
+    <artifactId>jspwiki-knowwe-api</artifactId>
     <name>Apache JSPWiki public API</name>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-event</artifactId>
+            <artifactId>jspwiki-knowwe-event</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-util</artifactId>
+            <artifactId>jspwiki-knowwe-util</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/jspwiki-bom/pom.xml
+++ b/jspwiki-bom/pom.xml
@@ -21,17 +21,17 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-bom</artifactId>
+  <artifactId>jspwiki-knowwe-bom</artifactId>
   <name>Apache JSPWiki bill of materials</name>
   <packaging>pom</packaging>
 
   <properties>
-    <jspwiki.version>3.0.0</jspwiki.version>
+    <jspwiki.version>3.0.0-SNAPSHOT</jspwiki.version>
   </properties>
 
   <dependencyManagement>
@@ -39,85 +39,85 @@
     <dependencies>
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-210-adapters</artifactId>
+        <artifactId>jspwiki-knowwe-210-adapters</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-210-test-adaptees</artifactId>
+        <artifactId>jspwiki-knowwe-210-test-adaptees</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-api</artifactId>
+        <artifactId>jspwiki-knowwe-api</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-bootstrap</artifactId>
+        <artifactId>jspwiki-knowwe-bootstrap</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-cache</artifactId>
+        <artifactId>jspwiki-knowwe-cache</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-event</artifactId>
+        <artifactId>jspwiki-knowwe-event</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-http</artifactId>
+        <artifactId>jspwiki-knowwe-http</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-kendra-searchprovider</artifactId>
+        <artifactId>jspwiki-knowwe-kendra-searchprovider</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-main</artifactId>
+        <artifactId>jspwiki-knowwe-main</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-markdown</artifactId>
+        <artifactId>jspwiki-knowwe-markdown</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-portable</artifactId>
+        <artifactId>jspwiki-knowwe-portable</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-tika-searchprovider</artifactId>
+        <artifactId>jspwiki-knowwe-tika-searchprovider</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-util</artifactId>
+        <artifactId>jspwiki-knowwe-util</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-war</artifactId>
+        <artifactId>jspwiki-knowwe-war</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
@@ -125,103 +125,103 @@
       <!-- integration tests artifacts -->
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-test-cma</artifactId>
+        <artifactId>jspwiki-knowwe-it-test-cma</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-test-cma-jdbc</artifactId>
+        <artifactId>jspwiki-knowwe-it-test-cma-jdbc</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-test-custom</artifactId>
+        <artifactId>jspwiki-knowwe-it-test-custom</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-test-custom-absolute-urls</artifactId>
+        <artifactId>jspwiki-knowwe-it-test-custom-absolute-urls</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-test-custom-jdbc</artifactId>
+        <artifactId>jspwiki-knowwe-it-test-custom-jdbc</artifactId>
         <version>${jspwiki.version}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-selenide-tests</artifactId>
+        <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <!-- wikipages artifacts -->
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-de</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-de</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-en</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-en</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-es</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-es</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-fi</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-fi</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-fr</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-fr</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-it</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-it</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-nl</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-nl</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-pt_BR</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-pt_BR</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-ru</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-ru</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.jspwiki.wikipages</groupId>
-        <artifactId>jspwiki-wikipages-zh_CN</artifactId>
+        <artifactId>jspwiki-knowwe-wikipages-zh_CN</artifactId>
         <version>${jspwiki.version}</version>
       </dependency>
     </dependencies>

--- a/jspwiki-bootstrap/pom.xml
+++ b/jspwiki-bootstrap/pom.xml
@@ -21,24 +21,24 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-bootstrap</artifactId>
+  <artifactId>jspwiki-knowwe-bootstrap</artifactId>
   <name>Apache JSPWiki bootstrapping procedures</name>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-util</artifactId>
+      <artifactId>jspwiki-knowwe-util</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/jspwiki-cache/pom.xml
+++ b/jspwiki-cache/pom.xml
@@ -21,24 +21,24 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-cache</artifactId>
+  <artifactId>jspwiki-knowwe-cache</artifactId>
   <name>Apache JSPWiki cache abstraction</name>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 
 	<dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-util</artifactId>
+      <artifactId>jspwiki-knowwe-util</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/jspwiki-event/pom.xml
+++ b/jspwiki-event/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-event</artifactId>
+  <artifactId>jspwiki-knowwe-event</artifactId>
   <name>Apache JSPWiki event subsystem</name>
 
 <dependencies>

--- a/jspwiki-http/pom.xml
+++ b/jspwiki-http/pom.xml
@@ -21,30 +21,30 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-http</artifactId>
+  <artifactId>jspwiki-knowwe-http</artifactId>
   <name>Apache JSPWiki http servlet and filters</name>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-util</artifactId>
+      <artifactId>jspwiki-knowwe-util</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-event</artifactId>
+      <artifactId>jspwiki-knowwe-event</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/jspwiki-it-tests/jspwiki-it-test-cma-jdbc/pom.xml
+++ b/jspwiki-it-tests/jspwiki-it-test-cma-jdbc/pom.xml
@@ -21,12 +21,12 @@
 
   <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- Container Managed Authentication using JDBC instead of XML files for user and group info -->
-  <artifactId>jspwiki-it-test-cma-jdbc</artifactId>
+  <artifactId>jspwiki-knowwe-it-test-cma-jdbc</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>functional tests execution for jspwiki-it-test-container-jdbc (container auth, relative URLs, JDBC database)</description>
   <packaging>war</packaging> <!-- tests reuse [2/3]: builds a war on top of jspwiki-war -->
@@ -60,7 +60,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-selenide-tests</artifactId>
+      <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jspwiki-it-tests/jspwiki-it-test-cma/pom.xml
+++ b/jspwiki-it-tests/jspwiki-it-test-cma/pom.xml
@@ -21,12 +21,12 @@
 
   <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
   <!-- Container Managed Authentication -->
-  <artifactId>jspwiki-it-test-cma</artifactId>
+  <artifactId>jspwiki-knowwe-it-test-cma</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>functional tests execution for jspwiki-it-test-container (container auth, relative URLs)</description>
   <packaging>war</packaging> <!-- tests reuse [2/3]: builds a war on top of jspwiki-war -->
@@ -55,7 +55,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-selenide-tests</artifactId>
+      <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jspwiki-it-tests/jspwiki-it-test-custom-absolute-urls/pom.xml
+++ b/jspwiki-it-tests/jspwiki-it-test-custom-absolute-urls/pom.xml
@@ -21,11 +21,11 @@
 
   <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
-  <artifactId>jspwiki-it-test-custom-absolute-urls</artifactId>
+  <artifactId>jspwiki-knowwe-it-test-custom-absolute-urls</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>functional tests execution for jspwiki-it-test-custom-absolute-urls (custom auth, absolute URLs)</description>
   <packaging>war</packaging> <!-- tests reuse [2/3]: builds a war on top of jspwiki-war -->
@@ -54,7 +54,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-selenide-tests</artifactId>
+      <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jspwiki-it-tests/jspwiki-it-test-custom-jdbc/pom.xml
+++ b/jspwiki-it-tests/jspwiki-it-test-custom-jdbc/pom.xml
@@ -21,11 +21,11 @@
 
   <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
-  <artifactId>jspwiki-it-test-custom-jdbc</artifactId>
+  <artifactId>jspwiki-knowwe-it-test-custom-jdbc</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>functional tests execution for jspwiki-it-test-custom (custom auth, JDBC database)</description>
   <packaging>war</packaging> <!-- tests reuse [2/3]: builds a war on top of jspwiki-war -->
@@ -59,7 +59,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-selenide-tests</artifactId>
+      <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jspwiki-it-tests/jspwiki-it-test-custom/pom.xml
+++ b/jspwiki-it-tests/jspwiki-it-test-custom/pom.xml
@@ -21,11 +21,11 @@
 
   <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
-  <artifactId>jspwiki-it-test-custom</artifactId>
+  <artifactId>jspwiki-knowwe-it-test-custom</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <packaging>war</packaging> <!-- tests reuse [2/3]: builds a war on top of jspwiki-war -->
   <description>functional tests execution for jspwiki-it-test-custom (custom auth, relative URLs)</description>
@@ -54,7 +54,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-selenide-tests</artifactId>
+      <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/pom.xml
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/pom.xml
@@ -21,11 +21,11 @@
 
   <parent>
     <groupId>org.apache.jspwiki.it</groupId>
-    <artifactId>jspwiki-it-tests</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-it-tests</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
   
-  <artifactId>jspwiki-selenide-tests</artifactId>
+  <artifactId>jspwiki-knowwe-selenide-tests</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>selenide tests for jspwiki</description>
   
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>org.apache.jspwiki</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/jspwiki-it-tests/jspwiki-test-plugin/pom.xml
+++ b/jspwiki-it-tests/jspwiki-test-plugin/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent> <!-- tests reuse [1/3]: reads common configuration for ITs and brings jspwiki-war as dependency -->
         <groupId>org.apache.jspwiki.it</groupId>
-        <artifactId>jspwiki-it-tests</artifactId>
-        <version>3.0.0</version>
+        <artifactId>jspwiki-knowwe-it-tests</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jspwiki-test-plugin</artifactId>
+    <artifactId>jspwiki-knowwe-test-plugin</artifactId>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.apache.jspwiki</groupId>
-            <artifactId>jspwiki-main</artifactId>
+            <artifactId>jspwiki-knowwe-main</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/jspwiki-it-tests/pom.xml
+++ b/jspwiki-it-tests/pom.xml
@@ -21,18 +21,18 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.jspwiki.it</groupId>
-  <artifactId>jspwiki-it-tests</artifactId>
+  <artifactId>jspwiki-knowwe-it-tests</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>selenium tests execution for jspwiki</description>
   <packaging>pom</packaging>
   <distributionManagement>
       <relocation>
-          <artifactId>jspwiki-it-builder</artifactId>
+          <artifactId>jspwiki-knowwe-it-builder</artifactId>
       </relocation>
   </distributionManagement>
   <modules>
@@ -48,7 +48,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.jspwiki</groupId>
-      <artifactId>jspwiki-war</artifactId>
+      <artifactId>jspwiki-knowwe-war</artifactId>
       <version>${project.version}</version>
       <type>war</type>
     </dependency>

--- a/jspwiki-kendra-searchprovider/pom.xml
+++ b/jspwiki-kendra-searchprovider/pom.xml
@@ -21,11 +21,11 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>jspwiki-kendra-searchprovider</artifactId>
+  <artifactId>jspwiki-knowwe-kendra-searchprovider</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <name>Apache JSPWiki AWS Kendra Search provider</name>
   <description>Apache JSPWiki Kendra Search provider</description>
@@ -33,14 +33,14 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/jspwiki-main/pom.xml
+++ b/jspwiki-main/pom.xml
@@ -21,12 +21,12 @@
 
     <parent>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-builder</artifactId>
-        <version>3.0.0</version>
+        <artifactId>jspwiki-knowwe-builder</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jspwiki-main</artifactId>
+    <artifactId>jspwiki-knowwe-main</artifactId>
     <name>Apache JSPWiki Main Jar</name>
 
     <dependencies>
@@ -43,37 +43,37 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-util</artifactId>
+            <artifactId>jspwiki-knowwe-util</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-event</artifactId>
+            <artifactId>jspwiki-knowwe-event</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-api</artifactId>
+            <artifactId>jspwiki-knowwe-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-cache</artifactId>
+            <artifactId>jspwiki-knowwe-cache</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-http</artifactId>
+            <artifactId>jspwiki-knowwe-http</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-wysiwyg</artifactId>
+            <artifactId>jspwiki-knowwe-wysiwyg</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/jspwiki-markdown/pom.xml
+++ b/jspwiki-markdown/pom.xml
@@ -21,11 +21,11 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>jspwiki-markdown</artifactId>
+  <artifactId>jspwiki-knowwe-markdown</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <name>Apache JSPWiki markdown support</name>
   <description>Apache JSPWiki markdown support</description>
@@ -33,26 +33,26 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
     </dependency>
   
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-wysiwyg</artifactId>
+      <artifactId>jspwiki-knowwe-wysiwyg</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/jspwiki-plugins/jspwiki-plugins-chartist/pom.xml
+++ b/jspwiki-plugins/jspwiki-plugins-chartist/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-plugins</artifactId>
-        <version>3.0.0</version>
+        <artifactId>jspwiki-knowwe-plugins</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jspwiki-plugins-chartist</artifactId>
+    <artifactId>jspwiki-knowwe-plugins-chartist</artifactId>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-main</artifactId>
+            <artifactId>jspwiki-knowwe-main</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/jspwiki-plugins/pom.xml
+++ b/jspwiki-plugins/pom.xml
@@ -21,11 +21,11 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>jspwiki-plugins</artifactId>
+  <artifactId>jspwiki-knowwe-plugins</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <description>Optional plugins for JSP wiki</description>
   <packaging>pom</packaging>

--- a/jspwiki-portable/pom.xml
+++ b/jspwiki-portable/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-portable</artifactId>
+  <artifactId>jspwiki-knowwe-portable</artifactId>
   <name>Apache JSPWiki portable</name>
 
   <properties>
@@ -179,7 +179,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.jspwiki</groupId>
-                  <artifactId>jspwiki-war</artifactId>
+                  <artifactId>jspwiki-knowwe-war</artifactId>
                   <version>${project.version}</version>
                   <type>war</type>
                 </artifactItem>
@@ -198,7 +198,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.jspwiki.wikipages</groupId>
-                  <artifactId>jspwiki-wikipages-${jspwiki.woas.language}</artifactId>
+                  <artifactId>jspwiki-knowwe-wikipages-${jspwiki.woas.language}</artifactId>
                   <version>${project.version}</version>
                 </artifactItem>
               </artifactItems>
@@ -217,7 +217,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.jspwiki.wikipages</groupId>
-                  <artifactId>jspwiki-wikipages-${jspwiki.woas.language}</artifactId>
+                  <artifactId>jspwiki-knowwe-wikipages-${jspwiki.woas.language}</artifactId>
                   <version>${project.version}</version>
                 </artifactItem>
               </artifactItems>
@@ -252,7 +252,7 @@
   <dependencies>
     <dependency><!-- added so we can issue safe, parallel builds -->
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-war</artifactId>
+      <artifactId>jspwiki-knowwe-war</artifactId>
       <version>${project.version}</version>
       <type>war</type>
       <scope>provided</scope>
@@ -271,7 +271,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-plugins-chartist</artifactId>
+      <artifactId>jspwiki-knowwe-plugins-chartist</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/jspwiki-tika-searchprovider/pom.xml
+++ b/jspwiki-tika-searchprovider/pom.xml
@@ -21,11 +21,11 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>jspwiki-tika-searchprovider</artifactId>
+  <artifactId>jspwiki-knowwe-tika-searchprovider</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <name>Apache JSPWiki Tika Search provider</name>
   <description>Apache JSPWiki Tika Search provider</description>
@@ -33,21 +33,21 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-main</artifactId>
+      <artifactId>jspwiki-knowwe-main</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/jspwiki-util/pom.xml
+++ b/jspwiki-util/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-util</artifactId>
+  <artifactId>jspwiki-knowwe-util</artifactId>
   <name>Apache JSPWiki utility classes</name>
 
   <dependencies>

--- a/jspwiki-war/pom.xml
+++ b/jspwiki-war/pom.xml
@@ -21,43 +21,37 @@
 
     <parent>
         <groupId>org.apache.jspwiki</groupId>
-        <artifactId>jspwiki-builder</artifactId>
-        <version>3.0.0</version>
+        <artifactId>jspwiki-knowwe-builder</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>jspwiki-war</artifactId>
+    <artifactId>jspwiki-knowwe-war</artifactId>
     <name>Apache JSPWiki Main War</name>
     <packaging>war</packaging>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-bootstrap</artifactId>
+            <artifactId>jspwiki-knowwe-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-main</artifactId>
+            <artifactId>jspwiki-knowwe-main</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-markdown</artifactId>
+            <artifactId>jspwiki-knowwe-markdown</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-210-adapters</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>jspwiki-kendra-searchprovider</artifactId>
+            <artifactId>jspwiki-knowwe-kendra-searchprovider</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -93,17 +87,17 @@
                 <dependencies>
                     <dependency> <!-- so jspwiki custom taglibs can be seen by the jsp compiler -->
                         <groupId>${project.groupId}</groupId>
-                        <artifactId>jspwiki-main</artifactId>
+                        <artifactId>jspwiki-knowwe-main</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>${project.groupId}</groupId>
-                        <artifactId>jspwiki-api</artifactId>
+                        <artifactId>jspwiki-knowwe-api</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>${project.groupId}</groupId>
-                        <artifactId>jspwiki-http</artifactId>
+                        <artifactId>jspwiki-knowwe-http</artifactId>
                         <version>${project.version}</version>
                     </dependency>
                     <dependency>
@@ -267,7 +261,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.apache.jspwiki.wikipages</groupId>
-                                    <artifactId>jspwiki-wikipages-en</artifactId>
+                                    <artifactId>jspwiki-knowwe-wikipages-en</artifactId>
                                     <version>${project.version}</version>
                                 </artifactItem>
                             </artifactItems>

--- a/jspwiki-wikipages/de/pom.xml
+++ b/jspwiki-wikipages/de/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-de</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-de</artifactId>
   <name>Apache JSPWiki initial wiki pages (de)</name>
 
   <scm>

--- a/jspwiki-wikipages/en/pom.xml
+++ b/jspwiki-wikipages/en/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-en</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-en</artifactId>
   <name>Apache JSPWiki initial wiki pages (en)</name>
 
   <scm>

--- a/jspwiki-wikipages/es/pom.xml
+++ b/jspwiki-wikipages/es/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-es</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-es</artifactId>
   <name>Apache JSPWiki initial wiki pages (es)</name>
 
   <scm>

--- a/jspwiki-wikipages/fi/pom.xml
+++ b/jspwiki-wikipages/fi/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-fi</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-fi</artifactId>
   <name>Apache JSPWiki initial wiki pages (fi)</name>
 
   <scm>

--- a/jspwiki-wikipages/fr/pom.xml
+++ b/jspwiki-wikipages/fr/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-fr</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-fr</artifactId>
   <name>Apache JSPWiki initial wiki pages (fr)</name>
 
   <scm>

--- a/jspwiki-wikipages/it/pom.xml
+++ b/jspwiki-wikipages/it/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-it</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-it</artifactId>
   <name>Apache JSPWiki initial wiki pages (it)</name>
 
   <scm>

--- a/jspwiki-wikipages/nl/pom.xml
+++ b/jspwiki-wikipages/nl/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-nl</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-nl</artifactId>
   <name>Apache JSPWiki initial wiki pages (nl)</name>
 
   <scm>

--- a/jspwiki-wikipages/pom.xml
+++ b/jspwiki-wikipages/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-builder</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
   <groupId>org.apache.jspwiki.wikipages</groupId>
   <name>Apache JSPWiki initial wiki pages builder</name>
   <packaging>pom</packaging>
@@ -63,7 +63,7 @@
   <dependencies>
     <dependency><!-- artificial dependency just to ensure that the wiki pages are built after the markdown module has generated the markdown pages -->
       <groupId>org.apache.jspwiki</groupId>
-      <artifactId>jspwiki-markdown</artifactId>
+      <artifactId>jspwiki-knowwe-markdown</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
       <exclusions>

--- a/jspwiki-wikipages/pt_BR/pom.xml
+++ b/jspwiki-wikipages/pt_BR/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-pt_BR</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-pt_BR</artifactId>
   <name>Apache JSPWiki initial wiki pages (pt_BR)</name>
 
   <scm>

--- a/jspwiki-wikipages/ru/pom.xml
+++ b/jspwiki-wikipages/ru/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-ru</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-ru</artifactId>
   <name>Apache JSPWiki initial wiki pages (ru)</name>
 
   <scm>

--- a/jspwiki-wikipages/zh_CN/pom.xml
+++ b/jspwiki-wikipages/zh_CN/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.jspwiki.wikipages</groupId>
-    <artifactId>jspwiki-wikipages-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-wikipages-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wikipages-zh_CN</artifactId>
+  <artifactId>jspwiki-knowwe-wikipages-zh_CN</artifactId>
   <name>Apache JSPWiki initial wiki pages (zh_CN)</name>
 
   <scm>

--- a/jspwiki-wysiwyg/pom.xml
+++ b/jspwiki-wysiwyg/pom.xml
@@ -21,24 +21,24 @@
 
   <parent>
     <groupId>org.apache.jspwiki</groupId>
-    <artifactId>jspwiki-builder</artifactId>
-    <version>3.0.0</version>
+    <artifactId>jspwiki-knowwe-builder</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jspwiki-wysiwyg</artifactId>
+  <artifactId>jspwiki-knowwe-wysiwyg</artifactId>
   <name>Apache JSPWiki WYSIWYG support classes</name>
 
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-api</artifactId>
+      <artifactId>jspwiki-knowwe-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>jspwiki-util</artifactId>
+      <artifactId>jspwiki-knowwe-util</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
   </parent>
 
   <groupId>org.apache.jspwiki</groupId>
-  <artifactId>jspwiki-builder</artifactId>
+  <artifactId>jspwiki-knowwe-builder</artifactId>
   <modelVersion>4.0.0</modelVersion>
   <name>Apache JSPWiki</name>
-  <version>3.0.0</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Apache JSPWiki is a leading open source WikiWiki engine, feature-rich
     and built around standard JEE components (Java, servlets, JSP).</description>
@@ -149,8 +149,6 @@
     <module>jspwiki-markdown</module>
     <module>jspwiki-tika-searchprovider</module>
     <module>jspwiki-kendra-searchprovider</module>
-    <module>jspwiki-210-test-adaptees</module>
-    <module>jspwiki-210-adapters</module>
     <module>jspwiki-war</module>
     <module>jspwiki-portable</module>
     <module>jspwiki-it-tests</module><!-- IT tests are launched only if -Pintegration-tests is given -->
@@ -921,7 +919,7 @@
             <!-- <deployables>
               <deployable>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>jspwiki-war</artifactId>
+                <artifactId>jspwiki-knowwe-war</artifactId>
                 <type>war</type>
                 <properties>
                   <context>/JSPWiki</context>


### PR DESCRIPTION
Adopts the `jspwiki-knowwe-*` artifact coordinates and `3.0.0-SNAPSHOT` development version across the reactor (parent `jspwiki-knowwe-builder`, apache parent already 35). Module directory names and reactor `<module>` paths are unchanged, so downstream KnowWE poms need only a version bump.

Also drops `jspwiki-210-adapters` and `jspwiki-210-test-adaptees` from the build and the war's dependency on them: they adapt the pre-2.10 public API against the externally published `2.11.0.M6` artifacts and are not used here (the fork excluded them too). Their source directories are left in place, just unbuilt.

Local `mvn -B -T 1C -DskipTests package` is green. Full `package` (with unit tests) runs in CI.