### PR TITLE
Add CSRF protection allow-list extension point

### DIFF
--- a/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
+++ b/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.apache.wiki.api.core.Engine;
 import org.apache.wiki.api.core.Session;
 import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.util.CsrfProtectionAllowList;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -54,12 +55,13 @@ public class CsrfProtectionFilter implements Filter {
     /** {@inheritDoc} */
     @Override
     public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain ) throws IOException, ServletException {
-        if( isPost( ( HttpServletRequest ) request ) ) {
+        if( isPost( ( HttpServletRequest ) request ) && !CsrfProtectionAllowList.isAllowListed( ( HttpServletRequest ) request ) ) {
             final Engine engine = Wiki.engine().find( request.getServletContext(), null );
             final Session session = Wiki.session().find( engine, ( HttpServletRequest ) request );
             if( !requestContainsValidCsrfToken( request, session ) ) {
                 LOG.error( "Incorrect {} param with value '{}' received for {}",
                            ANTICSRF_PARAM, request.getParameter( ANTICSRF_PARAM ), ( ( HttpServletRequest ) request ).getPathInfo() );
+                ( ( HttpServletResponse ) response ).setStatus( HttpServletResponse.SC_FORBIDDEN );
                 ( ( HttpServletResponse ) response ).sendRedirect( "/error/Forbidden.html" );
                 return;
             }
@@ -69,6 +71,9 @@ public class CsrfProtectionFilter implements Filter {
 
     public static boolean isCsrfProtectedPost( final HttpServletRequest request ) {
         if( isPost( request ) ) {
+            if( CsrfProtectionAllowList.isAllowListed( request ) ) {
+                return true;
+            }
             final Engine engine = Wiki.engine().find( request.getServletContext(), null );
             final Session session = Wiki.session().find( engine, request );
             return requestContainsValidCsrfToken( request, session );

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowList.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowList.java
@@ -1,0 +1,44 @@
+package org.apache.wiki.util;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Thread-safe registry of request checkers that may explicitly allowlist individual POST requests for the CSRF
+ * protection filter.
+ */
+public final class CsrfProtectionAllowList {
+
+	private static final Set<CsrfProtectionAllowListChecker> CHECKERS = new CopyOnWriteArraySet<>();
+
+	private CsrfProtectionAllowList() {
+	}
+
+	/**
+	 * Registers the given allowlist checker.
+	 *
+	 * @param checker the checker to register
+	 */
+	public static void register(CsrfProtectionAllowListChecker checker) {
+		if (checker != null) {
+			CHECKERS.add(checker);
+		}
+	}
+
+	/**
+	 * Returns whether any registered checker allowlists the given request.
+	 *
+	 * @param request the current HTTP request
+	 * @return {@code true} if the request is allowlisted, otherwise {@code false}
+	 */
+	public static boolean isAllowListed(HttpServletRequest request) {
+		for (CsrfProtectionAllowListChecker checker : CHECKERS) {
+			if (checker.isAllowListed(request)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowListChecker.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowListChecker.java
@@ -1,0 +1,19 @@
+package org.apache.wiki.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Strategy interface used by the CSRF protection filter to exempt selected POST requests from token validation.
+ * Implementations must be conservative and only allow strictly read-only requests.
+ */
+@FunctionalInterface
+public interface CsrfProtectionAllowListChecker {
+
+	/**
+	 * Returns whether the given request is explicitly allow-listed and may bypass the CSRF token check.
+	 *
+	 * @param request the current HTTP request
+	 * @return {@code true} if the request may bypass CSRF validation, otherwise {@code false}
+	 */
+	boolean isAllowListed(HttpServletRequest request);
+}


### PR DESCRIPTION
Ports the fork's CSRF allow-list feature (adapted to jakarta):
- new `CsrfProtectionAllowList` (thread-safe checker registry) and `CsrfProtectionAllowListChecker` (functional interface) in jspwiki-util
- `CsrfProtectionFilter` consults the registry so allow-listed read-only POSTs bypass token validation, and now sends `403 Forbidden` (status set) before redirect on token mismatch

Additive; `mvn -B -T1C -DskipTests package` green. Unit tests run in CI.