### PR TITLE
XmlUtil absolute-path support + ProviderException I/O cause ctor

### DIFF
--- a/jspwiki-api/src/main/java/org/apache/wiki/api/exceptions/ProviderException.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/exceptions/ProviderException.java
@@ -18,6 +18,8 @@
  */
 package org.apache.wiki.api.exceptions;
 
+import java.io.IOException;
+
 
 /**
  *  This exception represents the superclass of all exceptions that providers may throw.  It is okay to throw
@@ -35,6 +37,16 @@ public class ProviderException extends WikiException {
      */
     public ProviderException( final String msg ) {
         super( msg );
+    }
+
+    /**
+     *  Creates a ProviderException with a root cause.
+     *
+     *  @param msg exception message.
+     *  @param e the underlying I/O error.
+     */
+    public ProviderException( final String msg, final IOException e ) {
+        super( msg, e );
     }
 
 }

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
@@ -31,6 +31,7 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -60,7 +61,7 @@ public final class XmlUtil  {
 	 * Parses the given XML file and returns the requested nodes. If there's an error accessing or parsing the file, an
 	 * empty list is returned.
 	 * 
-	 * @param xml file to parse; matches all resources from classpath, filters repeated items.
+	 * @param xml file to parse; You can either provide an absolute path or it tries to  match all resources from classpath, filters repeated items.
 	 * @param requestedNodes requested nodes on the xml file
 	 * @return the requested nodes of the XML file.
 	 */
@@ -69,7 +70,15 @@ public final class XmlUtil  {
 			final Set< Element > readed = new HashSet<>();
 			final SAXBuilder builder = new SAXBuilder();
 			try {
-				final Enumeration< URL > resources = XmlUtil.class.getClassLoader().getResources( xml );
+				Enumeration<URL> resources = null;
+				File file = new File(xml);
+				if (file.isAbsolute() && file.exists()) {
+					URL resourceUrl = file.toURI().toURL();
+					resources = Collections.enumeration(List.of(resourceUrl));
+				}
+				else {
+					resources = XmlUtil.class.getClassLoader().getResources(xml);
+				}
 				while( resources.hasMoreElements() ) {
 					final URL resource = resources.nextElement();
 					LOG.debug( "reading {}", resource.toString() );


### PR DESCRIPTION
Two small, self-contained fork changes (upstream-untouched files):
- `XmlUtil.parse(String,String)` now accepts an absolute filesystem path, falling back to classpath resource lookup otherwise
- new `ProviderException(String, IOException)` constructor to wrap an I/O root cause

Additive; `mvn -B -T1C -DskipTests package` green. Tests run in CI.