### PR TITLE
Workflow disk-persist guard + SearchResult.toMap()

### DIFF
--- a/jspwiki-api/src/main/java/org/apache/wiki/api/search/SearchResult.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/search/SearchResult.java
@@ -18,6 +18,9 @@
  */
 package org.apache.wiki.api.search;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.wiki.api.core.Page;
 
 
@@ -47,5 +50,17 @@ public interface SearchResult {
      * @since 2.4
      */
     String[] getContexts();
+
+    /**
+     * Map representation of this search result, usable for example for JSON serialization.
+     *
+     * @return a map version of this search result
+     */
+    default Map<String,Object> toMap() {
+        HashMap<String,Object> jsonMap = new HashMap<>();
+        jsonMap.put( "page", getPage().getName() );
+        jsonMap.put( "score", getScore() );
+        return  jsonMap;
+    }
 
 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
@@ -290,8 +290,29 @@ public class DefaultWorkflowManager implements WorkflowManager, Serializable {
                 default: break;
                 }
             }
-            serializeToDisk( new File( m_engine.getWorkDir(), SERIALIZATION_FILE ) );
+            if( shouldSerializeToDisk( event ) ) {
+                serializeToDisk( new File( m_engine.getWorkDir(), SERIALIZATION_FILE ) );
+            }
         }
+    }
+
+    /**
+     * Persist only when queued decisions change.
+     *
+     * Waiting {@link Decision}s are the only workflow state that must survive a restart; workflows that
+     * immediately run to completion without waiting do not need disk persistence.
+     *
+     * @param event the workflow event to inspect
+     * @return {@code true} if the event changes recoverable waiting state
+     */
+    boolean shouldSerializeToDisk( final WikiEvent event ) {
+        if( !( event instanceof WorkflowEvent ) || !( event.getSrc() instanceof Decision ) ) {
+            return false;
+        }
+
+        return event.getType() == WorkflowEvent.DQ_ADDITION
+               || event.getType() == WorkflowEvent.DQ_REMOVAL
+               || event.getType() == WorkflowEvent.DQ_REASSIGN;
     }
 
     /**

--- a/jspwiki-main/src/test/java/org/apache/wiki/workflow/WorkflowManagerTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/workflow/WorkflowManagerTest.java
@@ -62,6 +62,22 @@ public class WorkflowManagerTest {
     }
 
     @Test
+    public void testShouldSerializeOnlyForDecisionQueueChanges() {
+        final Decision d = new SimpleDecision( w.getId(), w.getAttributes(), "decision.editWikiApproval", new WikiPrincipal( "Actor1" ) );
+
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.CREATED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.STARTED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.RUNNING ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.WAITING ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.COMPLETED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.ABORTED ) ) );
+
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_ADDITION ) ) );
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_REMOVAL ) ) );
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_REASSIGN ) ) );
+    }
+
+    @Test
     public void testStart() throws WikiException {
         // Once we start the workflow, it should show that it's started and the WM should have assigned it an ID
         Assertions.assertFalse( w.isStarted() );


### PR DESCRIPTION
Two self-contained fork changes (upstream-untouched files):
- `DefaultWorkflowManager` only serializes to disk on decision-queue changes (`DQ_ADDITION/REMOVAL/REASSIGN`) instead of on every workflow event — non-waiting workflows have no recoverable state. New `shouldSerializeToDisk(WikiEvent)` + a covering unit test.
- `SearchResult` gains a default `toMap()` (page name + score) for JSON serialization.

`mvn install` + `WorkflowManagerTest` (6 tests) green locally. Full suite in CI.