### PR TITLE
Low-level module features (util/api/event/cache/http)

### DIFF
--- a/jspwiki-api/src/main/java/org/apache/wiki/api/core/Engine.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/core/Engine.java
@@ -18,6 +18,7 @@
  */
 package org.apache.wiki.api.core;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.wiki.api.engine.EngineLifecycleExtension;
 import org.apache.wiki.api.events.CustomWikiEventListener;
@@ -252,18 +253,23 @@ public interface Engine {
      * @return the URL to the file
      */
     default URL findConfigFile( final String name ) {
-        LoggerFactory.getLogger( Engine.class ).info( "looking for " + name + " inside WEB-INF " );
+        final Logger log = LoggerFactory.getLogger( Engine.class );
+        log.info( "looking for " + name + " inside WEB-INF " );
         // Try creating an absolute path first
         File defaultFile = null;
         if( getRootPath() != null ) {
             defaultFile = new File( getRootPath() + "/WEB-INF/" + name );
         }
-        if ( defaultFile != null && defaultFile.exists() ) {
+        if( defaultFile == null || !defaultFile.exists() ) {
+            log.info( "looking for " + name + " as complete path" );
+            defaultFile = new File( name );
+        }
+        if ( defaultFile.exists() ) {
             try {
                 return defaultFile.toURI().toURL();
             } catch ( final MalformedURLException e ) {
                 // Shouldn't happen, but log it if it does
-                LoggerFactory.getLogger( Engine.class ).warn( "Malformed URL: " + e.getMessage() );
+                log.warn( "Malformed URL: " + e.getMessage() );
             }
         }
 
@@ -275,17 +281,18 @@ public interface Engine {
             try {
                 tmpFile = File.createTempFile( "temp." + name, "" );
             } catch( final IOException e ) {
-                LoggerFactory.getLogger( Engine.class ).error( "unable to create a temp file to load onto the policy", e );
+                log.error( "unable to create a temp file to load onto the policy", e );
                 return null;
             }
             tmpFile.deleteOnExit();
-            LoggerFactory.getLogger( Engine.class ).info( "looking for /" + name + " on classpath" );
+            log.info( "looking for /" + name + " on classpath" );
             //  create a tmp file of the policy loaded as an InputStream and return the URL to it
             try( final InputStream is = Engine.class.getResourceAsStream( "/" + name );
                 final OutputStream os = Files.newOutputStream( tmpFile.toPath() ) ) {
                 if( is == null ) {
                     throw new FileNotFoundException( name + " not found" );
                 }
+                log.info( "looking for servlet context resource /WEB-INF/" + name );
                 final URL url = getServletContext().getResource( "/WEB-INF/" + name );
                 if( url != null ) {
                     return url;
@@ -300,9 +307,9 @@ public interface Engine {
                 path = tmpFile.toURI().toURL();
             } catch( final MalformedURLException e ) {
                 // This should never happen unless I screw up
-                LoggerFactory.getLogger( Engine.class ).error( "Your code is b0rked.  You are a bad person.", e );
+                log.error( "Your code is b0rked.  You are a bad person.", e );
             } catch( final IOException e ) {
-                LoggerFactory.getLogger( Engine.class ).error( "failed to load security policy from file " + name + ",stacktrace follows", e );
+                log.error( "failed to load security policy from file " + name + ",stacktrace follows", e );
             }
         }
         return path;

--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
@@ -57,10 +57,11 @@ public class EhcacheCachingManager implements CachingManager, Initializable {
     /** {@inheritDoc} */
     @Override
     public void shutdown() {
-        if(!cacheMap.isEmpty()) {
-            CacheManager.getInstance().shutdown();
-            cacheMap.clear();
-            cacheStats.clear();
+        LOG.info( "Shutting down local CacheManager: " + cacheManager );
+        cacheMap.clear();
+        cacheStats.clear();
+        if( cacheManager != null ) { // in case initialize was not called, e.g. in tests
+            cacheManager.shutdown();
         }
     }
 

--- a/jspwiki-event/src/main/java/org/apache/wiki/event/WikiEventManager.java
+++ b/jspwiki-event/src/main/java/org/apache/wiki/event/WikiEventManager.java
@@ -453,7 +453,7 @@ public final class WikiEventManager {
             boolean needsCleanup = false;
             try {
                 synchronized( m_listenerList ) {
-                    for( final WeakReference< WikiEventListener > wikiEventListenerWeakReference : m_listenerList ) {
+                    for( final WeakReference< WikiEventListener > wikiEventListenerWeakReference : new ArrayList<>(m_listenerList) ) {
                         final WikiEventListener listener = wikiEventListenerWeakReference.get();
                         if( listener != null ) {
                             listener.actionPerformed( event );

--- a/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
+++ b/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.apache.wiki.api.core.Engine;
 import org.apache.wiki.api.core.Session;
 import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.util.CsrfProtectionAllowList;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -54,7 +55,7 @@ public class CsrfProtectionFilter implements Filter {
     /** {@inheritDoc} */
     @Override
     public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain ) throws IOException, ServletException {
-        if( isPost( ( HttpServletRequest ) request ) ) {
+        if( isPost( ( HttpServletRequest ) request ) && !CsrfProtectionAllowList.isAllowListed( ( HttpServletRequest ) request ) ) {
             final Engine engine = Wiki.engine().find( request.getServletContext(), null );
             final Session session = Wiki.session().find( engine, ( HttpServletRequest ) request );
             if( !requestContainsValidCsrfToken( request, session ) ) {
@@ -70,6 +71,9 @@ public class CsrfProtectionFilter implements Filter {
 
     public static boolean isCsrfProtectedPost( final HttpServletRequest request ) {
         if( isPost( request ) ) {
+            if( CsrfProtectionAllowList.isAllowListed( request ) ) {
+                return true;
+            }
             final Engine engine = Wiki.engine().find( request.getServletContext(), null );
             final Session session = Wiki.session().find( engine, request );
             return requestContainsValidCsrfToken( request, session );

--- a/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
+++ b/jspwiki-http/src/main/java/org/apache/wiki/http/filter/CsrfProtectionFilter.java
@@ -60,6 +60,7 @@ public class CsrfProtectionFilter implements Filter {
             if( !requestContainsValidCsrfToken( request, session ) ) {
                 LOG.error( "Incorrect {} param with value '{}' received for {}",
                            ANTICSRF_PARAM, request.getParameter( ANTICSRF_PARAM ), ( ( HttpServletRequest ) request ).getPathInfo() );
+                ( ( HttpServletResponse ) response ).setStatus( HttpServletResponse.SC_FORBIDDEN );
                 ( ( HttpServletResponse ) response ).sendRedirect( "/error/Forbidden.html" );
                 return;
             }

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/ClassUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/ClassUtil.java
@@ -49,8 +49,16 @@ public final class ClassUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClassUtil.class);
 
-    /** The location of the classmappings.xml document. It will be searched for in the classpath. Its value is "{@value}". */
-    public  static final String MAPPINGS = "ini/classmappings.xml";
+    /**
+     * System property to overwrite the class definition xml
+     */
+    public static final String CUSTOM_MAPPINGS = "jspwiki.custom.classmapping";
+    /**
+     *  The location of the classmappings.xml document. It will be searched for
+     *  in the classpath.  It's default value is "ini/classmappings.xml", but may be overwritten with
+     *  the system property "{@value CUSTOM_MAPPINGS}".
+     */
+    public static final String MAPPINGS = System.getProperty(CUSTOM_MAPPINGS, "ini/classmappings.xml");
 
     /** The location of the classmappings-extra.xml document. It will be searched for in the classpath. Its value is "{@value}". */
     public  static final String MAPPINGS_EXTRA = "ini/classmappings-extra.xml";

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowList.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowList.java
@@ -1,0 +1,44 @@
+package org.apache.wiki.util;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Thread-safe registry of request checkers that may explicitly allowlist individual POST requests for the CSRF
+ * protection filter.
+ */
+public final class CsrfProtectionAllowList {
+
+	private static final Set<CsrfProtectionAllowListChecker> CHECKERS = new CopyOnWriteArraySet<>();
+
+	private CsrfProtectionAllowList() {
+	}
+
+	/**
+	 * Registers the given allowlist checker.
+	 *
+	 * @param checker the checker to register
+	 */
+	public static void register(CsrfProtectionAllowListChecker checker) {
+		if (checker != null) {
+			CHECKERS.add(checker);
+		}
+	}
+
+	/**
+	 * Returns whether any registered checker allowlists the given request.
+	 *
+	 * @param request the current HTTP request
+	 * @return {@code true} if the request is allowlisted, otherwise {@code false}
+	 */
+	public static boolean isAllowListed(HttpServletRequest request) {
+		for (CsrfProtectionAllowListChecker checker : CHECKERS) {
+			if (checker.isAllowListed(request)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowListChecker.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/CsrfProtectionAllowListChecker.java
@@ -1,0 +1,19 @@
+package org.apache.wiki.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Strategy interface used by the CSRF protection filter to exempt selected POST requests from token validation.
+ * Implementations must be conservative and only allow strictly read-only requests.
+ */
+@FunctionalInterface
+public interface CsrfProtectionAllowListChecker {
+
+	/**
+	 * Returns whether the given request is explicitly allow-listed and may bypass the CSRF token check.
+	 *
+	 * @param request the current HTTP request
+	 * @return {@code true} if the request may bypass CSRF validation, otherwise {@code false}
+	 */
+	boolean isAllowListed(HttpServletRequest request);
+}

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/HttpUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/HttpUtil.java
@@ -138,6 +138,10 @@ public final class HttpUtil {
      *  @return the result of the check
      */
     public static boolean checkFor304( final HttpServletRequest req, final String pageName, final Date lastModified ) {
+        //if there is no date passed we assume that it has changed!
+        if(lastModified==null){
+            return false;
+        }
         // We'll do some handling for CONDITIONAL GET (and return a 304). If the client has set the following headers, do not try for a 304.
         //    pragma: no-cache
         //    cache-control: no-cache

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
@@ -77,8 +77,9 @@ public final class PropertyReader {
 
     private static final String PARAM_VAR_DECLARATION = "var.";
     private static final String PARAM_VAR_IDENTIFIER  = "$";
+	private static Properties webAppProps;
 
-    /**
+	/**
      *  Private constructor to prevent instantiation.
      */
     private PropertyReader()
@@ -128,7 +129,14 @@ public final class PropertyReader {
      *  @return A filled Properties object with all the cascaded properties in place
      */
     public static Properties loadWebAppProps( final ServletContext context ) {
-        final String propertyFile = getInitParameter( context, PARAM_CUSTOMCONFIG );
+        if (webAppProps == null) {
+        	webAppProps = initWebAppProps(context);
+        }
+        return webAppProps;
+    }
+
+    private static Properties initWebAppProps(ServletContext context) {
+        final String propertyFile = getInitParameter(context, PARAM_CUSTOMCONFIG );
         try( final InputStream propertyStream = loadCustomPropertiesFile(context, propertyFile) ) {
             final Properties props = getDefaultProperties();
 
@@ -146,13 +154,13 @@ public final class PropertyReader {
             LOG.debug( "Loading cascading properties..." );
 
             // now load the cascade (new in 2.5)
-            loadWebAppPropsCascade( context, props );
+            loadWebAppPropsCascade(context, props );
 
             // property expansion so we can resolve things like ${TOMCAT_HOME}
             propertyExpansion( props );
 
             // sets the JSPWiki working directory (jspwiki.workDir)
-            setWorkDir( context, props );
+            setWorkDir(context, props );
 
             // add system properties beginning with jspwiki...
             final Map< String, String > sysprops = collectPropertiesFrom( System.getProperties().entrySet().stream()
@@ -166,7 +174,6 @@ public final class PropertyReader {
         } catch( final Exception e ) {
             LOG.error( "JSPWiki: Unable to load and setup properties from jspwiki.properties. " + e.getMessage(), e );
         }
-
         return null;
     }
 

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
@@ -459,15 +459,9 @@ public final class PropertyReader {
     static void setWorkDir( final ServletContext servletContext, final Properties properties ) {
         final String workDir = TextUtil.getStringProperty(properties, "jspwiki.workDir", null);
         if (workDir == null) {
-            final File tempDir = (File) servletContext.getAttribute("jakarta.servlet.context.tempdir");
-            if (tempDir != null) {
-                properties.setProperty("jspwiki.workDir", tempDir.getAbsolutePath());
-                LOG.info("Setting jspwiki.workDir to ServletContext's temporary directory: {}", tempDir.getAbsolutePath());
-            } else {
-                final String defaultTmpDir = System.getProperty("java.io.tmpdir");
-                properties.setProperty("jspwiki.workDir", defaultTmpDir);
-                LOG.info("ServletContext's temporary directory not found. Setting jspwiki.workDir to system's temporary directory: {}", defaultTmpDir);
-            }
+            final String defaultTmpDir = System.getProperty("java.io.tmpdir");
+            properties.setProperty("jspwiki.workDir", defaultTmpDir);
+            LOG.info(" Setting jspwiki.workDir to system's temporary directory: {}", defaultTmpDir);
         } else {
             LOG.info("jspwiki.workDir is already set to: {}", workDir);
         }

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/TextUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/TextUtil.java
@@ -315,6 +315,7 @@ public final class TextUtil {
      *  @return The parsed value (or defvalue).
      */
     public static int parseIntParameter( final String value, final int defvalue ) {
+        if (value == null) return defvalue;
         try {
             return Integer.parseInt( value.trim() );
         } catch( final Exception e ) {

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/TextUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/TextUtil.java
@@ -54,7 +54,7 @@ public final class TextUtil {
     public static final String LEGACY_CHARS_ALLOWED = "._";
 
     /** Lists all punctuation characters allowed in page names. */
-    public static final String PUNCTUATION_CHARS_ALLOWED = " ()&+,-=._$";
+    public static final String PUNCTUATION_CHARS_ALLOWED = " ()&+,-=._$@";
 
     /** Private constructor prevents instantiation. */
     private TextUtil() {}

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
@@ -31,6 +31,7 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -60,7 +61,7 @@ public final class XmlUtil  {
 	 * Parses the given XML file and returns the requested nodes. If there's an error accessing or parsing the file, an
 	 * empty list is returned.
 	 * 
-	 * @param xml file to parse; matches all resources from classpath, filters repeated items.
+	 * @param xml file to parse; You can either provide an absolute path or it tries to  match all resources from classpath, filters repeated items.
 	 * @param requestedNodes requested nodes on the xml file
 	 * @return the requested nodes of the XML file.
 	 */
@@ -69,7 +70,15 @@ public final class XmlUtil  {
 			final Set< Element > readed = new HashSet<>();
 			final SAXBuilder builder = new SAXBuilder();
 			try {
-				final Enumeration< URL > resources = XmlUtil.class.getClassLoader().getResources( xml );
+				Enumeration<URL> resources = null;
+				File file = new File(xml);
+				if (file.isAbsolute() && file.exists()) {
+					URL resourceUrl = file.toURI().toURL();
+					resources = Collections.enumeration(List.of(resourceUrl));
+				}
+				else {
+					resources = XmlUtil.class.getClassLoader().getResources(xml);
+				}
 				while( resources.hasMoreElements() ) {
 					final URL resource = resources.nextElement();
 					LOG.debug( "reading {}", resource.toString() );

--- a/jspwiki-util/src/test/java/org/apache/wiki/util/PropertyReaderTest.java
+++ b/jspwiki-util/src/test/java/org/apache/wiki/util/PropertyReaderTest.java
@@ -134,18 +134,18 @@ class PropertyReaderTest {
         final File tmp = new File( "/tmp" );
         Mockito.when(servletContext.getAttribute( "jakarta.servlet.context.tempdir" ) ).thenReturn( tmp );
 
-        PropertyReader.setWorkDir( servletContext, properties );
-
-        // Test when the "jspwiki.workDir" is not set, it should get set to servlet's temporary directory
-        PropertyReader.setWorkDir(servletContext, properties);
-        String workDir = properties.getProperty("jspwiki.workDir");
-        Assertions.assertEquals(tmp.getAbsolutePath(), workDir);
+        // servlet's temp dir will no longer be used -> comment out
+//        PropertyReader.setWorkDir( servletContext, properties );
+//
+//        // Test when the "jspwiki.workDir" is not set, it should get set to servlet's temporary directory
+//        String workDir = properties.getProperty( "jspwiki.workDir" );
+//        Assertions.assertEquals( tmp.getAbsolutePath(), workDir );
 
         // Test when the "jspwiki.workDir" is set, it should remain as it is
-        properties.setProperty("jspwiki.workDir", "/custom/dir");
-        PropertyReader.setWorkDir(servletContext, properties);
-        workDir = properties.getProperty("jspwiki.workDir");
-        Assertions.assertEquals("/custom/dir", workDir);
+        properties.setProperty( "jspwiki.workDir", "/custom/dir" );
+        PropertyReader.setWorkDir( servletContext, properties );
+        String workDir = properties.getProperty( "jspwiki.workDir" );
+        Assertions.assertEquals( "/custom/dir", workDir );
 
         // Test when the servlet's temporary directory is null, it should get set to system's temporary directory
         Mockito.when( servletContext.getAttribute( "jakarta.servlet.context.tempdir" ) ).thenReturn( null );

--- a/jspwiki-util/src/test/java/org/apache/wiki/util/XmlUtilTest.java
+++ b/jspwiki-util/src/test/java/org/apache/wiki/util/XmlUtilTest.java
@@ -57,6 +57,7 @@ public class XmlUtilTest {
 
         elements = XmlUtil.parse( ClassUtil.MAPPINGS, "/classmappings/mapping" );
         Assertions.assertEquals( 1, elements.size() );
+
     }
 
     @Test


### PR DESCRIPTION
Ports the fork's foundational low-level changes onto the 3.0 base (authorship-preserving cherry-picks):

- CSRF allow-list extension point (`CsrfProtectionAllowList`/`Checker`) + filter wiring + 403 on invalid token.
- `XmlUtil`/`ClassUtil`: support absolute paths for classmappings; custom classmapping system property.
- `Engine.findConfigFile` compatibility fix (complete-path fallback).
- `TextUtil` null handling; `@` allowed in page names; `HttpUtil` no-NPE on missing last-modified.
- workDir defaults to system temp dir; cache webapp props; ehcache shutdown null-check; misc NPE/CME fixes.

Logging call sites use slf4j (backend from the logging cluster).