### PR TITLE
jspwiki-main features (search, auth, attachments, sessions, i18n)

### DIFF
--- a/jspwiki-api/src/main/java/org/apache/wiki/api/search/SearchResult.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/search/SearchResult.java
@@ -20,6 +20,9 @@ package org.apache.wiki.api.search;
 
 import org.apache.wiki.api.core.Page;
 
+import java.util.HashMap;
+import java.util.Map;
+
 
 /**
  *  Defines a search result.
@@ -47,5 +50,17 @@ public interface SearchResult {
      * @since 2.4
      */
     String[] getContexts();
+
+    /**
+     * Returns a map version of this search result, to allow easier search customization.
+     *
+     * @return a map version of this search result
+     */
+    default Map<String,Object> toMap() {
+        final HashMap<String,Object> jsonMap = new HashMap<>();
+        jsonMap.put( "page", getPage().getName() );
+        jsonMap.put( "score", getScore() );
+        return jsonMap;
+    }
 
 }

--- a/jspwiki-main/pom.xml
+++ b/jspwiki-main/pom.xml
@@ -289,12 +289,6 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <excludes>
-                                <exclude>**/test*/**</exclude>
-                                <exclude>**/*Test.class</exclude>
-                                <exclude>**/*Test$*.class</exclude>
-                                <exclude>**/*Tests.class</exclude>
-                            </excludes>
                             <skip>false</skip>
                             <skipIfEmpty>true</skipIfEmpty>
                         </configuration>

--- a/jspwiki-main/pom.xml
+++ b/jspwiki-main/pom.xml
@@ -30,7 +30,13 @@
     <name>Apache JSPWiki Main Jar</name>
 
     <dependencies>
-        
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>19.0.0</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
@@ -466,17 +466,27 @@ public class WikiEngine implements Engine {
             }
         }
     }
-
     /**
      *  Initializes the reference manager. Scans all existing WikiPages for
      *  internal links and adds them to the ReferenceManager object.
      *
      *  @throws WikiException If the reference manager initialization fails.
      */
+
     public void initReferenceManager() throws WikiException {
+        initReferenceManager(false);
+    }
+    /**
+     *  Initializes the reference manager. Scans all existing WikiPages for
+     *  internal links and adds them to the ReferenceManager object.
+     *  @param reinit if false: does init only if no instance of a ReferenceManager exists
+     *                if true: if a ReferenceManager exists, it will be dismissed and a new one will be initialized
+     *  @throws WikiException If the reference manager initialization fails.
+     */
+    public void initReferenceManager(boolean reinit) throws WikiException {
         try {
             // Build a new manager with default key lists.
-            if( getManager( ReferenceManager.class ) == null ) {
+            if( getManager( ReferenceManager.class ) == null || reinit) {
                 final ArrayList< Page > pages = new ArrayList<>();
                 pages.addAll( getManager( PageManager.class ).getAllPages() );
                 pages.addAll( getManager( AttachmentManager.class ).getAllAttachments() );

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
@@ -268,8 +268,7 @@ public class WikiEngine implements Engine {
         m_useUTF8        = StandardCharsets.UTF_8.name().equals( TextUtil.getStringProperty( props, PROP_ENCODING, StandardCharsets.ISO_8859_1.name() ) );
         m_saveUserInfo   = TextUtil.getBooleanProperty( props, PROP_STOREUSERNAME, m_saveUserInfo );
         m_frontPage      = TextUtil.getStringProperty( props, PROP_FRONTPAGE, "Main" );
-        m_templateDir    = TextUtil.getStringProperty( props, PROP_TEMPLATEDIR, "default" );
-        enforceValidTemplateDirectory();
+        updateTemplateDir();
 
         //
         //  Initialize the important modules.  Any exception thrown by the managers means that we will not start up.
@@ -353,6 +352,11 @@ public class WikiEngine implements Engine {
         
         new SecurityVerificationUtility().verify(this);
         m_isConfigured = true;
+    }
+
+    public void updateTemplateDir() {
+        m_templateDir    = TextUtil.getStringProperty(m_properties, PROP_TEMPLATEDIR, "default" );
+        enforceValidTemplateDirectory();
     }
 
     void createAndFindWorkingDirectory( final Properties props ) throws WikiException {

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
@@ -43,6 +43,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.net.http.HttpRequest;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -208,8 +209,7 @@ public class WikiSession implements Session {
     public Principal[] getPrincipals() {
 
         // Take the first non Role as the main Principal
-
-        return m_subject.getPrincipals().stream().filter(AuthenticationManager::isUserPrincipal).toArray(Principal[]::new);
+        return new ArrayList<>( m_subject.getPrincipals() ).stream().filter( AuthenticationManager::isUserPrincipal ).toArray( Principal[]::new );
     }
 
     /** {@inheritDoc} */

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
@@ -45,12 +45,14 @@ import java.net.http.HttpRequest;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -66,7 +68,7 @@ public class WikiSession implements Session {
 
     private static final String ALL = "*";
 
-    private static final ThreadLocal< Session > c_guestSession = new ThreadLocal<>();
+    private static final Map<Thread, Session> c_guestSession = Collections.synchronizedMap(new WeakHashMap<>());
 
     private final Subject m_subject = new Subject();
 
@@ -472,7 +474,7 @@ public class WikiSession implements Session {
         }
         final SessionMonitor monitor = SessionMonitor.getInstance( engine );
         monitor.remove( request.getSession() );
-        c_guestSession.remove();
+        c_guestSession.remove(Thread.currentThread());
     }
 
     /**
@@ -548,15 +550,8 @@ public class WikiSession implements Session {
      *  @param engine Engine for this session
      *  @return A static WikiSession which is shared by all in this same Thread.
      */
-    // FIXME: Should really use WeakReferences to clean away unused sessions.
     private static Session staticGuestSession( final Engine engine ) {
-        Session session = c_guestSession.get();
-        if( session == null ) {
-            session = guestSession( engine );
-            c_guestSession.set( session );
-        }
-
-        return session;
+        return c_guestSession.computeIfAbsent(Thread.currentThread(), k -> guestSession(engine));
     }
 
     /**

--- a/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentServlet.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentServlet.java
@@ -419,7 +419,9 @@ public class AttachmentServlet extends HttpServlet {
             final Context context = Wiki.context().create( m_engine, req, ContextEnum.PAGE_ATTACH.getRequestContext() );
             final UploadListener pl = new UploadListener();
 
-            m_engine.getManager( ProgressManager.class ).startProgress( pl, progressId );
+            if( progressId != null ) {
+                m_engine.getManager( ProgressManager.class ).startProgress( pl, progressId );
+            }
             
             if (req.getContentLengthLong() > m_maxSize) {
                 //we don't want total upload size to be larger than the max

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthenticationManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthenticationManager.java
@@ -162,7 +162,8 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
         final Session session = SessionMonitor.getInstance( m_engine ).find( httpSession );
         final AuthenticationManager authenticationMgr = m_engine.getManager( AuthenticationManager.class );
         final AuthorizationManager authorizationMgr = m_engine.getManager( AuthorizationManager.class );
-        CallbackHandler handler = null;
+        // Create a callback handler, because sometimes it is missed in isAnonymous block
+        CallbackHandler handler = new WebContainerCallbackHandler(m_engine, request);
         final Map< String, String > options = EMPTY_MAP;
 
         // If user not authenticated, check if container logged them in, or if there's an authentication cookie

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthorizationManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthorizationManager.java
@@ -87,7 +87,8 @@ public class DefaultAuthorizationManager implements AuthorizationManager {
 
     private Engine m_engine;
 
-    private LocalPolicy m_localPolicy;
+    protected LocalPolicy m_localPolicy;
+    protected File policyFile;
 
     /**
      * Constructs a new DefaultAuthorizationManager instance.
@@ -241,7 +242,7 @@ public class DefaultAuthorizationManager implements AuthorizationManager {
             final URL policyURL = engine.findConfigFile( policyFileName );
 
             if (policyURL != null) {
-                final File policyFile = new File( policyURL.toURI().getPath() );
+                policyFile = new File( policyURL.toURI().getPath() );
                 LOG.info("We found security policy URL: {} and transformed it to file {}",policyURL, policyFile.getAbsolutePath());
                 m_localPolicy = new LocalPolicy( policyFile, engine.getContentEncoding().displayName() );
                 m_localPolicy.refresh();

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
@@ -542,7 +542,7 @@ public class XMLUserDatabase extends AbstractUserDatabase {
                 if( StringUtils.isEmpty( lockExpiry ) || lockExpiry.isEmpty() ) {
                     profile.setLockExpiry( null );
                 } else {
-                    profile.setLockExpiry( new Date( Long.parseLong( lockExpiry ) ) );
+                    profile.setLockExpiry( parseDate( profile, lockExpiry ) );
                 }
                 final String oldHahes = user.getAttribute(OLD_HASHES_TAG);
                 if (oldHahes != null && oldHahes.length() > 0) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/i18n/InternationalizationManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/i18n/InternationalizationManager.java
@@ -19,6 +19,8 @@
 package org.apache.wiki.i18n;
 
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
@@ -59,11 +61,13 @@ public interface InternationalizationManager {
      *  @throws MissingResourceException If the key cannot be located at all, even from the default locale.
      */
     default ResourceBundle getBundle( final String bundle, Locale locale ) throws MissingResourceException {
-        if( locale == null ) {
-            locale = Locale.getDefault();
-        }
 
-        return ResourceBundle.getBundle( bundle, locale );
+        return ResourceBundle.getBundle( bundle, Locale.ROOT , new ResourceBundle.Control() {
+            @Override
+            public List<Locale> getCandidateLocales(String baseName, Locale locale1) {
+                return Collections.singletonList(Locale.ROOT);
+            }
+        });
     }
 
     /**

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
@@ -274,10 +274,7 @@ public class DefaultSearchManager extends BasePageFilter implements SearchManage
                     int count = 0;
                     for( final Iterator< SearchResult > i = c.iterator(); i.hasNext() && count < maxLength; count++ ) {
                         final SearchResult sr = i.next();
-                        final HashMap< String, Object > hm = new HashMap<>();
-                        hm.put( "page", sr.getPage().getName() );
-                        hm.put( "score", sr.getScore() );
-                        list.add( hm );
+                        list.add( sr.toMap() );
                     }
                 } catch( final Exception e ) {
                     LOG.info( "AJAX search failed; ", e );

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
@@ -200,7 +200,8 @@ public class DefaultSearchManager extends BasePageFilter implements SearchManage
                 } else if( actionName.equals( AJAX_ACTION_PAGES ) ) {
                     LOG.debug("Calling findPages() START");
                     final Context wikiContext = Wiki.context().create( m_engine, req, ContextEnum.PAGE_VIEW.getRequestContext() );
-                    final List< Map< String, Object > > callResults = findPages( itemId, maxResults, wikiContext );
+                    String query = params.size() > 2 ? String.join(",", params.subList(0, params.size() - 1)) : itemId;
+					final List< Map< String, Object > > callResults = findPages( query, maxResults, wikiContext );
                     LOG.debug( "Calling findPages() DONE. " + callResults.size() );
                     result = AjaxUtil.toJson( callResults );
                 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/DefaultSearchManager.java
@@ -275,6 +275,7 @@ public class DefaultSearchManager extends BasePageFilter implements SearchManage
                     int count = 0;
                     for( final Iterator< SearchResult > i = c.iterator(); i.hasNext() && count < maxLength; count++ ) {
                         final SearchResult sr = i.next();
+                        if ( sr == null) continue;
                         list.add( sr.toMap() );
                     }
                 } catch( final Exception e ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -98,7 +98,7 @@ public class LuceneSearchProvider implements SearchProvider {
 
     protected static final Logger LOG = LoggerFactory.getLogger( LuceneSearchProvider.class );
 
-    private Engine m_engine;
+    protected Engine m_engine;
     private Executor searchExecutor;
 
     // Lucene properties.
@@ -124,7 +124,7 @@ public class LuceneSearchProvider implements SearchProvider {
     protected static final String LUCENE_PAGE_NAME     = "name";
     protected static final String LUCENE_PAGE_KEYWORDS = "keywords";
 
-    private String m_luceneDirectory;
+    protected String m_luceneDirectory;
     protected final List< Object[] > m_updates = Collections.synchronizedList( new ArrayList<>() );
 
     /** Maximum number of fragments from search matches. */
@@ -585,7 +585,7 @@ public class LuceneSearchProvider implements SearchProvider {
     }
 
     // FIXME: This class is dumb; needs to have a better implementation
-    private static class SearchResultImpl implements SearchResult {
+    protected static class SearchResultImpl implements SearchResult {
 
         private final Page m_page;
         private final int m_score;

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -172,7 +172,10 @@ public class LuceneSearchProvider implements SearchProvider {
 	 * Override/change the return value of this method if the index changes, to make sure a new index is generated
 	 */
 	protected String getIndexId() {
-		return "v1";
+		// bumped v1 -> v2 for the Lucene 6.6.6 -> 10 upgrade: Lucene 10 cannot open a v6 on-disk index
+		// (IndexFormatTooOldException). A new id routes to a fresh directory so the search index is rebuilt
+		// from the wiki pages instead of crashing; the old v6 directory is simply left unused.
+		return "v2";
 	}
 
     /**

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -77,6 +77,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -140,7 +141,7 @@ public class LuceneSearchProvider implements SearchProvider {
         m_engine = engine;
         searchExecutor = Executors.newCachedThreadPool();
 
-        m_luceneDirectory = engine.getWorkDir() + File.separator + LUCENE_DIR;
+        m_luceneDirectory = engine.getWorkDir() + File.separator + LUCENE_DIR + File.separator + Paths.get(props.getProperty("var.basedir", "unknown-wiki")).getFileName();
 
         final int initialDelay = TextUtil.getIntegerProperty( props, PROP_LUCENE_INITIALDELAY, LuceneUpdater.INITIAL_DELAY );
         final int indexDelay   = TextUtil.getIntegerProperty( props, PROP_LUCENE_INDEXDELAY, LuceneUpdater.INDEX_DELAY );

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -132,8 +132,7 @@ public class LuceneSearchProvider implements SearchProvider {
 
     /** The maximum number of hits to return from searches. */
     public static final int MAX_SEARCH_HITS = 99_999;
-
-    private static final String PUNCTUATION_TO_SPACES = StringUtils.repeat( " ", TextUtil.PUNCTUATION_CHARS_ALLOWED.length() );
+    protected static final String PUNCTUATION_TO_SPACES = StringUtils.repeat( " ", TextUtil.PUNCTUATION_CHARS_ALLOWED.length() );
 
     /** {@inheritDoc} */
     @Override

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -324,7 +324,7 @@ public class LuceneSearchProvider implements SearchProvider {
         LOG.debug( "Done updating Lucene index for page '{}'.", page.getName() );
     }
 
-    private Analyzer getLuceneAnalyzer() throws ProviderException {
+    protected Analyzer getLuceneAnalyzer() throws ProviderException {
         try {
             return ClassUtil.buildInstance( m_analyzerClass );
         } catch( final Exception e ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -80,6 +80,13 @@ import java.io.StringWriter;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -80,13 +80,6 @@ import java.io.StringWriter;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 
@@ -141,7 +134,7 @@ public class LuceneSearchProvider implements SearchProvider {
         m_engine = engine;
         searchExecutor = Executors.newCachedThreadPool();
 
-        m_luceneDirectory = engine.getWorkDir() + File.separator + LUCENE_DIR + File.separator + Paths.get(props.getProperty("var.basedir", "unknown-wiki")).getFileName();
+        m_luceneDirectory = engine.getWorkDir() + File.separator + LUCENE_DIR + File.separator + getIndexId() + File.separator + Paths.get(props.getProperty("var.basedir", "unknown-wiki")).getFileName();
 
         final int initialDelay = TextUtil.getIntegerProperty( props, PROP_LUCENE_INITIALDELAY, LuceneUpdater.INITIAL_DELAY );
         final int indexDelay   = TextUtil.getIntegerProperty( props, PROP_LUCENE_INDEXDELAY, LuceneUpdater.INDEX_DELAY );
@@ -174,6 +167,13 @@ public class LuceneSearchProvider implements SearchProvider {
         final LuceneUpdater updater = new LuceneUpdater( m_engine, this, initialDelay, indexDelay );
         updater.start();
     }
+
+	/**
+	 * Override/change the return value of this method if the index changes, to make sure a new index is generated
+	 */
+	protected String getIndexId() {
+		return "v1";
+	}
 
     /**
      * Returns the handling engine.

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -49,7 +49,7 @@ import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.SimpleHTMLEncoder;
 import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.FSDirectory;
 import org.apache.wiki.InternalWikiException;
 import org.apache.wiki.WatchDog;
 import org.apache.wiki.WikiBackgroundThread;
@@ -205,7 +205,7 @@ public class LuceneSearchProvider implements SearchProvider {
 
                 LOG.info( "Starting Lucene reindexing, this can take a couple of minutes..." );
 
-                final Directory luceneDir = new NIOFSDirectory( dir.toPath() );
+                final Directory luceneDir = FSDirectory.open( dir.toPath() );
                 try( final IndexWriter writer = getIndexWriter( luceneDir ) ) {
                     long pagesIndexed = 0L;
                     final Collection< Page > allPages = m_engine.getManager( PageManager.class ).getAllPages();
@@ -310,7 +310,7 @@ public class LuceneSearchProvider implements SearchProvider {
         pageRemoved( page );
 
         // Now add back the new version.
-        try( final Directory luceneDir = new NIOFSDirectory( new File( m_luceneDirectory ).toPath() );
+        try( final Directory luceneDir = FSDirectory.open( new File( m_luceneDirectory ).toPath() );
              final IndexWriter writer = getIndexWriter( luceneDir ) ) {
             luceneIndexPage( page, text, writer );
         } catch( final IOException e ) {
@@ -403,7 +403,7 @@ public class LuceneSearchProvider implements SearchProvider {
      */
     @Override
     public synchronized void pageRemoved( final Page page ) {
-        try( final Directory luceneDir = new NIOFSDirectory( new File( m_luceneDirectory ).toPath() );
+        try( final Directory luceneDir = FSDirectory.open( new File( m_luceneDirectory ).toPath() );
              final IndexWriter writer = getIndexWriter( luceneDir ) ) {
             final Query query = new TermQuery( new Term( LUCENE_ID, page.getName() ) );
             writer.deleteDocuments( query );
@@ -467,7 +467,7 @@ public class LuceneSearchProvider implements SearchProvider {
         ArrayList< SearchResult > list = null;
         Highlighter highlighter = null;
 
-        try( final Directory luceneDir = new NIOFSDirectory( new File( m_luceneDirectory ).toPath() );
+        try( final Directory luceneDir = FSDirectory.open( new File( m_luceneDirectory ).toPath() );
              final IndexReader reader = DirectoryReader.open( luceneDir ) ) {
             final String[] queryfields = { LUCENE_PAGE_CONTENTS, LUCENE_PAGE_NAME, LUCENE_AUTHOR, LUCENE_ATTACHMENTS, LUCENE_PAGE_KEYWORDS };
             final QueryParser qp = new MultiFieldQueryParser( queryfields, getLuceneAnalyzer() );

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
@@ -113,17 +113,17 @@ public class BreadcrumbsTag extends WikiTagBase
     @Override
     public int doWikiStartTag() throws IOException {
         final HttpSession session = pageContext.getSession();
-        FixedQueue trail = (FixedQueue) session.getAttribute(BREADCRUMBTRAIL_KEY);
+        FixedQueue trail = new FixedQueue(m_maxQueueSize);
+        FixedQueue existing = (FixedQueue) session.getAttribute(BREADCRUMBTRAIL_KEY);
+        if (existing != null) {
+            trail.addAll(existing);
+        }
         final String page = m_wikiContext.getPage().getName();
 
-        if( trail == null ) {
-            trail = new FixedQueue(m_maxQueueSize);
-        } else {
-            //  check if page still exists (could be deleted/renamed by another user)
-            for (int i = 0;i<trail.size();i++) {
-                if( !m_wikiContext.getEngine().getManager( PageManager.class ).wikiPageExists( trail.get( i ) ) ) {
-                    trail.remove(i);
-                }
+        //  check if page still exists (could be deleted/renamed by another user)
+        for (int i = 0;i<trail.size();i++) {
+            if( !m_wikiContext.getEngine().getManager( PageManager.class ).wikiPageExists( trail.get( i ) ) ) {
+                trail.remove(i);
             }
         }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
@@ -130,11 +130,11 @@ public class BreadcrumbsTag extends WikiTagBase
         if( m_wikiContext.getRequestContext().equals( ContextEnum.PAGE_VIEW.getRequestContext() ) ) {
             if( m_wikiContext.getEngine().getManager( PageManager.class ).wikiPageExists( page ) ) {
                 if( trail.isEmpty() ) {
-                    trail.pushItem( page );
+                    if ( page != null) trail.pushItem( page );
                 } else {
                     // Don't add the page to the queue if the page was just refreshed
                     if( !trail.getLast().equals( page ) ) {
-                        trail.pushItem( page );
+                        if ( page != null) trail.pushItem( page );
                     }
                 }
             } else {
@@ -184,7 +184,7 @@ public class BreadcrumbsTag extends WikiTagBase
             m_size = size;
         }
 
-        String pushItem( final String o ) {
+        synchronized String pushItem( final String o ) {
             remove(o);
             add( o );
             if( size() > m_size ) {
@@ -197,7 +197,7 @@ public class BreadcrumbsTag extends WikiTagBase
         /**
          * @param pageName the page to be deleted from the breadcrumb
          */
-        public void removeItem( final String pageName ) {
+        synchronized public void removeItem( final String pageName ) {
             for( int i = 0; i < size(); i++ ) {
                 final String page = get( i );
                 //noinspection ConstantConditions

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
@@ -199,7 +199,8 @@ public class BreadcrumbsTag extends WikiTagBase
         public void removeItem( final String pageName ) {
             for( int i = 0; i < size(); i++ ) {
                 final String page = get( i );
-                if( page != null && page.equals( pageName ) ) {
+                //noinspection ConstantConditions
+                if (!(page instanceof String) || (page != null && page.equals(pageName))) {
                     remove( page );
                 }
             }

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/BreadcrumbsTag.java
@@ -185,6 +185,7 @@ public class BreadcrumbsTag extends WikiTagBase
         }
 
         String pushItem( final String o ) {
+            remove(o);
             add( o );
             if( size() > m_size ) {
                 return removeFirst();

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/DefaultCommandResolver.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/DefaultCommandResolver.java
@@ -21,6 +21,7 @@ package org.apache.wiki.ui;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 import org.apache.wiki.InternalWikiException;
+import org.apache.wiki.WikiContext;
 import org.apache.wiki.api.core.Command;
 import org.apache.wiki.api.core.Engine;
 import org.apache.wiki.api.core.Page;
@@ -35,6 +36,7 @@ import org.apache.wiki.util.TextUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -272,6 +274,11 @@ public class DefaultCommandResolver implements CommandResolver {
         try {
             String page = m_engine.getManager( URLConstructor.class ).parsePage( requestContext, request, m_engine.getContentEncoding() );
             if ( page != null ) {
+                if (!(WikiContext.ATTACH.equals(requestContext) || WikiContext.DELETE.equals(requestContext))) {
+                    // page requests come encoded, attachment requests (att + del) come decoded...
+                    // so if attachment name contains a +, it would get decoded to white space, causing 404
+                    page = URLDecoder.decode(page, m_engine.getContentEncoding());
+                }
                 try {
                     // Look for singular/plural variants; if one not found, take the one the user supplied
                     final String finalPage = getFinalPageName( page );

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
@@ -40,6 +40,16 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.Vector;
 
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.jstl.fmt.LocaleSupport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.i18n.InternationalizationManager;
+import org.apache.wiki.modules.ModuleManager;
+import org.apache.wiki.preferences.Preferences;
+import org.apache.wiki.util.ClassUtil;
+
 
 /**
  *  This class takes care of managing JSPWiki templates.  This class also provides the ResourceRequest mechanism.
@@ -61,6 +71,9 @@ public interface TemplateManager extends ModuleManager {
 
     /** Requests a script to be loaded. Value is {@value}. */
     String RESOURCE_SCRIPT = "script";
+
+    /** Requests a script to be loaded as module. Value is {@value}. */
+    String RESOURCE_SCRIPT_MODULE = "module";
 
     /** Requests inlined CSS. Value is {@value}. */
     String RESOURCE_INLINECSS = "inlinecss";
@@ -322,7 +335,10 @@ public interface TemplateManager extends ModuleManager {
             resourcemap = new HashMap<>();
         }
 
-        Vector< String > resources = resourcemap.get( type );
+        // Module has to be treated as script for further processing of RESOURCE_INCLUDES variable
+        final String resourceType = type.equals(RESOURCE_SCRIPT_MODULE) ? RESOURCE_SCRIPT : type;
+
+        Vector< String > resources = resourcemap.get( resourceType );
         if( resources == null ) {
             resources = new Vector<>();
         }
@@ -336,6 +352,9 @@ public interface TemplateManager extends ModuleManager {
 
         String resourceString = null;
         switch( type ) {
+        case RESOURCE_SCRIPT_MODULE:
+            resourceString = "<script type='module' src='" + resource + "'></script>";
+            break;
         case RESOURCE_SCRIPT:
             resourceString = "<script type='text/javascript' src='" + resolvedResource + "'></script>";
             break;
@@ -357,7 +376,7 @@ public interface TemplateManager extends ModuleManager {
 
         LoggerFactory.getLogger( TemplateManager.class ).debug( "Request to add a resource: {}", resourceString );
 
-        resourcemap.put( type, resources );
+        resourcemap.put(resourceType, resources );
         ctx.setVariable( RESOURCE_INCLUDES, resourcemap );
     }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
@@ -40,16 +40,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.Vector;
 
-import javax.servlet.jsp.PageContext;
-import javax.servlet.jsp.jstl.fmt.LocaleSupport;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.wiki.api.core.Context;
-import org.apache.wiki.i18n.InternationalizationManager;
-import org.apache.wiki.modules.ModuleManager;
-import org.apache.wiki.preferences.Preferences;
-import org.apache.wiki.util.ClassUtil;
-
 
 /**
  *  This class takes care of managing JSPWiki templates.  This class also provides the ResourceRequest mechanism.

--- a/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
@@ -290,8 +290,29 @@ public class DefaultWorkflowManager implements WorkflowManager, Serializable {
                 default: break;
                 }
             }
-            serializeToDisk( new File( m_engine.getWorkDir(), SERIALIZATION_FILE ) );
+            if( shouldSerializeToDisk( event ) ) {
+                serializeToDisk( new File( m_engine.getWorkDir(), SERIALIZATION_FILE ) );
+            }
         }
+    }
+
+    /**
+     * Persist only when queued decisions change.
+     *
+     * Waiting {@link Decision}s are the only workflow state that must survive a restart; workflows that
+     * immediately run to completion without waiting do not need disk persistence.
+     *
+     * @param event the workflow event to inspect
+     * @return {@code true} if the event changes recoverable waiting state
+     */
+    boolean shouldSerializeToDisk( final WikiEvent event ) {
+        if( !( event instanceof WorkflowEvent ) || !( event.getSrc() instanceof Decision ) ) {
+            return false;
+        }
+
+        return event.getType() == WorkflowEvent.DQ_ADDITION
+               || event.getType() == WorkflowEvent.DQ_REMOVAL
+               || event.getType() == WorkflowEvent.DQ_REASSIGN;
     }
 
     /**

--- a/jspwiki-main/src/main/resources/ini/classmappings.xml
+++ b/jspwiki-main/src/main/resources/ini/classmappings.xml
@@ -146,5 +146,9 @@
   <mapping>
     <requestedClass>org.apache.wiki.workflow.WorkflowManager</requestedClass>
     <mappedClass>org.apache.wiki.workflow.DefaultWorkflowManager</mappedClass>
+	</mapping>
+	<mapping>
+		<requestedClass>org.apache.wiki.cache.CachingManager</requestedClass>
+		<mappedClass>org.apache.wiki.cache.EhcacheCachingManager</mappedClass>
   </mapping>
 </classmappings>

--- a/jspwiki-main/src/main/resources/templates/default.properties
+++ b/jspwiki-main/src/main/resources/templates/default.properties
@@ -192,7 +192,7 @@ info.updatereferrers=Update referrers?
 info.rename.permission=Only authorized users are allowed to rename pages.
 
 
-info.delete.submit=Delete entire page
+info.delete.submit=Delete page content
 #info.delete.attachmentwarning=<i>First delete all attachments of this page</i>
 info.confirmdelete=Please confirm that you want to delete this content permanently!
 info.delete.permission=Only authorized users are allowed to delete pages.

--- a/jspwiki-main/src/main/resources/templates/default_de.properties
+++ b/jspwiki-main/src/main/resources/templates/default_de.properties
@@ -224,7 +224,7 @@ info.rename.submit=Seite umbenennen
 info.updatereferrers=referenzierende Seiten aktualisieren
 info.rename.permission=Du bist nicht autorisiert, diese Seite umzubenennen.
 
-info.delete.submit=Komplette Seite l\u00f6schen
+info.delete.submit=Seite leeren
 info.confirmdelete=Soll dieser Inhalt wirklich dauerhaft gel\u00f6scht werden?
 info.delete.permission=Du bist nicht autorisiert, diese Seite zu l\u00f6schen.
 

--- a/jspwiki-main/src/test/java/org/apache/wiki/workflow/WorkflowManagerTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/workflow/WorkflowManagerTest.java
@@ -131,4 +131,20 @@ public class WorkflowManagerTest {
         Assertions.assertEquals( 1, wm.m_completed.size() );
     }
 
+    @Test
+    public void testShouldSerializeOnlyForDecisionQueueChanges() {
+        final Decision d = new SimpleDecision( w.getId(), w.getAttributes(), "decision.editWikiApproval", new WikiPrincipal( "Actor1" ) );
+
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.CREATED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.STARTED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.RUNNING ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.WAITING ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.COMPLETED ) ) );
+        Assertions.assertFalse( wm.shouldSerializeToDisk( new WorkflowEvent( w, WorkflowEvent.ABORTED ) ) );
+
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_ADDITION ) ) );
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_REMOVAL ) ) );
+        Assertions.assertTrue( wm.shouldSerializeToDisk( new WorkflowEvent( d, WorkflowEvent.DQ_REASSIGN ) ) );
+    }
+
 }


### PR DESCRIPTION
Ports the fork's jspwiki-main feature commits onto the 3.0 base (authorship-preserving cherry-picks). Highlights:

- Search: SearchResult JSON `toMap()`, per-wiki Lucene index folders, search-manager tweaks.
- Sessions/auth: ConcurrentModification-safe principal snapshots, WeakHashMap guest sessions, misc NPE guards.
- Attachments: NPE guard when uploading without a progress id.
- UI/i18n: script `type=module` resource support, clarified delete-button texts.
- Build: jetbrains annotations dep; test classes included in the main test-jar.

Deferred to later passes (recorded in ledger): IndexPlugin ignore-prefix rewrite, TemplateManager single-request resource dedup, page-name-resolver-dependent changes (cluster 5), lucene-migration steps already covered by the 3.0 base.