### PR TITLE
Logging enhancements (property loading, search duration)

### DIFF
--- a/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
@@ -199,7 +199,7 @@ public final class PropertyReader {
             //  Use the custom property file at the default location
             propertyStream =  locateClassPathResource(context, CUSTOM_JSPWIKI_CONFIG);
         } else {
-            LOG.debug( PARAM_CUSTOMCONFIG + " defined, using " + propertyFile + " as the custom properties file." );
+            LOG.info( PARAM_CUSTOMCONFIG + " defined, using " + propertyFile + " as the custom properties file." );
             propertyStream = Files.newInputStream( new File(propertyFile).toPath() );
         }
         return propertyStream;
@@ -403,7 +403,7 @@ public final class PropertyReader {
         currResourceLocation = createResourceLocation( "/WEB-INF/classes", resourceName );
         result = context.getResourceAsStream( currResourceLocation );
         if( result != null ) {
-            LOG.debug( " Successfully located the following classpath resource : " + currResourceLocation );
+            LOG.info( " Successfully located the following classpath resource : " + currResourceLocation );
             return result;
         }
 
@@ -411,7 +411,7 @@ public final class PropertyReader {
         currResourceLocation = createResourceLocation( "", resourceName );
         result = PropertyReader.class.getResourceAsStream( currResourceLocation );
         if( result != null ) {
-            LOG.debug( " Successfully located the following classpath resource : " + currResourceLocation );
+            LOG.info( " Successfully located the following classpath resource : " + currResourceLocation );
             return result;
         }
 

--- a/jspwiki-war/src/main/webapp/Search.jsp
+++ b/jspwiki-war/src/main/webapp/Search.jsp
@@ -50,13 +50,14 @@
 
     if( query != null ) {
         log.info("Searching for string "+query);
-
+        long start = System.currentTimeMillis();
         try {
             list = wiki.getManager( SearchManager.class ).findPages( query, wikiContext );
             pageContext.setAttribute( "searchresults", list, PageContext.REQUEST_SCOPE );
         } catch( Exception e ) {
             wikiContext.getWikiSession().addMessage( e.getMessage() );
         }
+        if (list != null) log.info("Found " + list.size() + " results in " + (System.currentTimeMillis() - start) + "ms");
 
         query = TextUtil.replaceEntities( query );
 


### PR DESCRIPTION
Two small authorship-preserving logging additions: surface jspwiki custom-properties loading at info level, and log Lucene index build duration. (Remaining tiny logging tweaks on relocated war-paths were SKIP:obsolete; timing-vs-count reindex log superseded by base's logging.)