### PR TITLE
Port small clusters: IndexPlugin, TemplateManager, denkbares repos

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
@@ -19,9 +19,8 @@
 
 package org.apache.wiki.plugin;
 
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.wiki.api.core.Context;
 import org.apache.wiki.api.core.ContextEnum;
 import org.apache.wiki.api.exceptions.PluginException;
@@ -34,122 +33,172 @@ import org.jdom2.Namespace;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
- *  A Plugin that creates an index of pages according to a certain pattern.
- *  <br />
- *  The default is to include all pages.
- *  <p>
- *  This is a rewrite of the earlier JSPWiki IndexPlugin using JDOM2.
- 8  </p>
- *  <p>
- *  Parameters (from AbstractReferralPlugin):
- *  </p>
- *  <ul>
- *    <li><b>include</b> - A regexp pattern for marking which pages should be included.</li>
- *    <li><b>exclude</b> - A regexp pattern for marking which pages should be excluded.</li>
- *  </ul>
- *  
+ * A Plugin that creates an index of pages according to a certain pattern.
+ * <br />
+ * The default is to include all pages.
+ * <p>
+ * This is a rewrite of the earlier JSPWiki IndexPlugin using JDOM2.
+ * 8  </p>
+ * <p>
+ * Parameters (from AbstractReferralPlugin):
+ * </p>
+ * <ul>
+ *   <li><b>include</b> - A regexp pattern for marking which pages should be included.</li>
+ *   <li><b>exclude</b> - A regexp pattern for marking which pages should be excluded.</li>
+ * </ul>
+ *
  * @author Ichiro Furusato
  */
 public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 
-    private static final Logger LOG = LoggerFactory.getLogger(IndexPlugin.class);
+	private static final Logger log = LogManager.getLogger(IndexPlugin.class);
 
-    private final Namespace xmlns_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
-   
-    @Override
-    public String getDisplayName(Locale locale) {
-        final ResourceBundle rb = ResourceBundle.getBundle(PluginManager.PLUGIN_I18N_RESOURCE, locale);
-        return rb.getString(this.getClass().getSimpleName());
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String execute( final Context context, final Map<String,String> params ) throws PluginException {
-        final String include = params.get(PARAM_INCLUDE);
-        final String exclude = params.get(PARAM_EXCLUDE);
-        
-        final Element masterDiv = getElement("div","index");
-        final Element indexDiv = getElement("div","header");
-        masterDiv.addContent(indexDiv);
-        try {
-            final List<String> pages = listPages(context,include,exclude);
-            context.getEngine().getManager( PageManager.class ).getPageSorter().sort(pages);
-            char initialChar = ' ';
-            Element currentDiv = new Element("div",xmlns_XHTML);            
-            for( final String name : pages ) {
-                if( StringUtils.isNotBlank( name ) &&  name.charAt(0) != initialChar ) {
-                    if ( initialChar != ' ' ) {
-                        indexDiv.addContent(" - ");
-                    }                    
-                    initialChar = name.charAt(0);
-                    masterDiv.addContent(makeHeader(String.valueOf(initialChar)));
-                    currentDiv = getElement("div","body");
-                    masterDiv.addContent(currentDiv);
-                    indexDiv.addContent(getLink("#"+initialChar,String.valueOf(initialChar)));
-                } else {
-                    currentDiv.addContent(", ");
-                }
-                currentDiv.addContent( getLink( context.getURL( ContextEnum.PAGE_VIEW.getRequestContext(), name ), name ) );
-            }
-            
-        } catch( final ProviderException e ) {
-            LOG.warn("could not load page index",e);
-            throw new PluginException( e.getMessage() );
-        }
-        // serialize to raw format string (no changes to whitespace)
-        final XMLOutputter out = new XMLOutputter(Format.getRawFormat());
-        return out.outputString(masterDiv);
-    }
+	private final Namespace xmlns_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
 
-    private Element getLink( final String href, final String content ) {
-        final Element a = new Element( "a", xmlns_XHTML );
-        a.setAttribute( "href", href );
-        a.addContent( content );
-        return a;
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String execute(final Context context, final Map<String, String> params) throws PluginException {
+		final String include = params.get(PARAM_INCLUDE);
+		final String exclude = params.get(PARAM_EXCLUDE);
+		final String ignorePrefix = params.get("ignorePrefix");
+		Pattern pattern = Pattern.compile("^(" + ignorePrefix + ")");
 
-    private Element makeHeader( final String initialChar ) {
-        final Element span = getElement( "span", "section" );
-        final Element a = new Element( "a", xmlns_XHTML );
-        a.setAttribute( "id", initialChar );
-        a.addContent( initialChar );
-        span.addContent( a );
-        return span;
-    }
+		final Element masterDiv = getElement("div", "index");
+		final Element indexDiv = getElement("div", "header");
+		masterDiv.addContent(indexDiv);
+		try {
+			final List<String> pages = listPages(context, include, exclude, ignorePrefix);
+			char initialChar = ' ';
+			Element currentDiv = new Element("div", xmlns_XHTML);
+			for (final String name : pages) {
+				Matcher matcher = pattern.matcher(name);
+				String pageNameSortedAfter = name;
+				boolean prefixIgnored = matcher.find();
+				if (prefixIgnored) {
+					pageNameSortedAfter = name.substring(matcher.end());
+					if (pageNameSortedAfter.isEmpty()) pageNameSortedAfter = name;
+				}
+				if (!String.valueOf(pageNameSortedAfter.charAt(0)).equalsIgnoreCase(String.valueOf(initialChar))) {
+					if (initialChar != ' ') {
+						indexDiv.addContent(" - ");
+					}
+					initialChar = name.charAt(0);
+					if (prefixIgnored) {
+						initialChar = Character.toUpperCase(pageNameSortedAfter.charAt(0));
+					}
+					masterDiv.addContent(makeHeader(String.valueOf(initialChar)));
+					currentDiv = getElement("div", "body");
+					masterDiv.addContent(currentDiv);
+					indexDiv.addContent(getLink("#" + initialChar, String.valueOf(initialChar)));
+				}
+				else {
+					currentDiv.addContent(", ");
+				}
+				currentDiv.addContent(getLink(context.getURL(ContextEnum.PAGE_VIEW.getRequestContext(), name), name));
+			}
+		}
+		catch (final ProviderException e) {
+			log.warn("could not load page index", e);
+			throw new PluginException(e.getMessage());
+		}
+		// serialize to raw format string (no changes to whitespace)
+		final XMLOutputter out = new XMLOutputter(Format.getRawFormat());
+		return out.outputString(masterDiv);
+	}
 
-    private Element getElement( final String gi, final String classValue ) {
-        final Element elt = new Element( gi, xmlns_XHTML );
-        elt.setAttribute( "class", classValue );
-        return elt;
-    }
+	private Element getLink(final String href, final String content) {
+		final Element a = new Element("a", xmlns_XHTML);
+		a.setAttribute("href", href);
+		a.addContent(content);
+		return a;
+	}
 
-    /**
-     *  Grabs a list of all pages and filters them according to the include/exclude patterns.
-     *  
-     * @param context
-     * @param include
-     * @param exclude
-     * @return A list containing page names which matched the filters.
-     * @throws ProviderException
-     */
-    private List<String> listPages( final Context context, final String include, final String exclude ) throws ProviderException {
-        final Pattern includePtrn = include != null ? Pattern.compile( include ) : Pattern.compile(".*");
-        final Pattern excludePtrn = exclude != null ? Pattern.compile( exclude ) : Pattern.compile("\\p{Cntrl}"); // there are no control characters in page names
-        final List< String > result;
-        final Set< String > pages = context.getEngine().getManager( ReferenceManager.class ).findCreated();
-        result = pages.stream().filter(pageName -> !excludePtrn.matcher(pageName).matches()).filter(pageName -> includePtrn.matcher(pageName).matches()).collect(Collectors.toList());
-        return result;
-    }
+	private Element makeHeader(final String initialChar) {
+		final Element span = getElement("span", "section");
+		final Element a = new Element("a", xmlns_XHTML);
+		a.setAttribute("id", initialChar);
+		a.addContent(initialChar);
+		span.addContent(a);
+		return span;
+	}
 
+	private Element getElement(final String gi, final String classValue) {
+		final Element elt = new Element(gi, xmlns_XHTML);
+		elt.setAttribute("class", classValue);
+		return elt;
+	}
+
+	/**
+	 * Grabs a list of all pages and filters them according to the include/exclude patterns.
+	 *
+	 * @param context      Provides engine and manager access. Non-null.
+	 * @param include      Regex to include pages. Null means 'include all'.
+	 * @param exclude      Regex to exclude pages. Null means 'exclude none'.
+	 * @param ignorePrefix Regex pattern specifying prefixes to ignore during sorting. Null indicates no prefixes are
+	 *                     ignored.
+	 * @return A list containing page names which matched the filters.
+	 * @throws ProviderException
+	 */
+	private List<String> listPages(final Context context, final String include, final String exclude, final String ignorePrefix) throws ProviderException {
+		final Pattern includePtrn = include != null ? Pattern.compile(include) : Pattern.compile(".*");
+		final Pattern excludePtrn = exclude != null ? Pattern.compile(exclude) : Pattern.compile("\\p{Cntrl}"); // there are no control characters in page names
+		final List<String> result = new ArrayList<>();
+		final Set<String> pages = context.getEngine().getManager(ReferenceManager.class).findCreated();
+		Pattern pattern = Pattern.compile("^(" + ignorePrefix + ")");
+		Map<String, String> pageNamePrefix = new HashMap<>();
+		for (final String pageName : pages) {
+			if (excludePtrn.matcher(pageName).matches()) {
+				continue;
+			}
+			if (includePtrn.matcher(pageName).matches()) {
+				if (ignorePrefix != null) {
+					Matcher matcher = pattern.matcher(pageName);
+					String pageNameSortedAfter = pageName;
+					if (matcher.find()) {
+						pageNameSortedAfter = pageName.substring(matcher.end());
+						if (pageNameSortedAfter.isEmpty()) pageNameSortedAfter = pageName;
+						pageNamePrefix.put(pageName, pageNameSortedAfter.substring(0, 1)
+								.toUpperCase() + pageNameSortedAfter.substring(1));
+					}
+					pageNameSortedAfter = pageNameSortedAfter.substring(0, 1)
+							.toUpperCase() + pageNameSortedAfter.substring(1);
+					result.add(pageNameSortedAfter);
+				}
+			}
+		}
+		context.getEngine().getManager(PageManager.class).getPageSorter().sort(result);
+
+		if (ignorePrefix != null && ignorePrefix.isEmpty()) {
+			return result;
+		}
+		else {
+			return getSortedPagesIncludingIgnoredPrefixes(result, pageNamePrefix);
+		}
+	}
+
+	private static List<String> getSortedPagesIncludingIgnoredPrefixes(List<String> result, Map<String, String> pageNamePrefix) {
+		for (Map.Entry<String, String> entry : pageNamePrefix.entrySet()) {
+			String nameWithPrefix = entry.getKey();
+			String nameWithoutPrefix = entry.getValue();
+
+			for (int i = 0; i < result.size(); i++) {
+				if (result.get(i).equals(nameWithoutPrefix)) {
+					result.set(i, nameWithPrefix);
+					break;
+				}
+			}
+		}
+		return result;
+	}
 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
  */
 public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 
-	private static final Logger log = LoggerFactory.getLogger(IndexPlugin.class);
+	private static final Logger LOG = LoggerFactory.getLogger(IndexPlugin.class);
 
 	private final Namespace xmlns_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
 
@@ -112,7 +112,7 @@ public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 			}
 		}
 		catch (final ProviderException e) {
-			log.warn("could not load page index", e);
+			LOG.warn("could not load page index", e);
 			throw new PluginException(e.getMessage());
 		}
 		// serialize to raw format string (no changes to whitespace)

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/IndexPlugin.java
@@ -19,8 +19,9 @@
 
 package org.apache.wiki.plugin;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.wiki.api.core.Page;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.apache.wiki.api.core.Context;
 import org.apache.wiki.api.core.ContextEnum;
 import org.apache.wiki.api.exceptions.PluginException;
@@ -34,12 +35,14 @@ import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * A Plugin that creates an index of pages according to a certain pattern.
@@ -60,7 +63,7 @@ import java.util.regex.Pattern;
  */
 public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 
-	private static final Logger log = LogManager.getLogger(IndexPlugin.class);
+	private static final Logger log = LoggerFactory.getLogger(IndexPlugin.class);
 
 	private final Namespace xmlns_XHTML = Namespace.getNamespace("http://www.w3.org/1999/xhtml");
 
@@ -148,15 +151,17 @@ public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 	 * @param pattern Regex pattern specifying prefixes to ignore during sorting. Null indicates no prefixes are
 	 *                ignored.
 	 * @return A list containing page names which matched the filters.
-	 * @throws ProviderException
+	 * @throws ProviderException in case of back end issues
 	 */
 	private List<String> listPages(final Context context, final String include, final String exclude, final Pattern pattern) throws ProviderException {
 		final Pattern includePtrn = include != null ? Pattern.compile(include) : Pattern.compile(".*");
 		final Pattern excludePtrn = exclude != null ? Pattern.compile(exclude) : Pattern.compile("\\p{Cntrl}"); // there are no control characters in page names
 		final List<String> result = new ArrayList<>();
-		final Set<String> pages = context.getEngine().getManager(ReferenceManager.class).findCreated();
+		PageManager pageManager = context.getEngine().getManager(PageManager.class);
+		final Collection<Page> pages = pageManager.getAllPages();
 		Map<String, String> pageNamePrefix = new HashMap<>();
-		for (final String pageName : pages) {
+		for (final Page page : pages) {
+			String pageName = page.getName();
 			if (excludePtrn.matcher(pageName).matches()) {
 				continue;
 			}
@@ -176,7 +181,7 @@ public class IndexPlugin extends AbstractReferralPlugin implements Plugin {
 				result.add(pageNameSortedAfter);
 			}
 		}
-		context.getEngine().getManager(PageManager.class).getPageSorter().sort(result);
+		pageManager.getPageSorter().sort(result);
 
 		if (pattern == null) {
 			return result;

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/TemplateManager.java
@@ -18,17 +18,7 @@
  */
 package org.apache.wiki.ui;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Strings;
-import org.slf4j.LoggerFactory;
-import org.apache.wiki.api.core.Context;
-import org.apache.wiki.i18n.InternationalizationManager;
-import org.apache.wiki.modules.ModuleManager;
-import org.apache.wiki.preferences.Preferences;
-import org.apache.wiki.util.ClassUtil;
-
-import jakarta.servlet.jsp.PageContext;
-import jakarta.servlet.jsp.jstl.fmt.LocaleSupport;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -39,6 +29,17 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.Vector;
+
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.jstl.fmt.LocaleSupport;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.LoggerFactory;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.i18n.InternationalizationManager;
+import org.apache.wiki.modules.ModuleManager;
+import org.apache.wiki.preferences.Preferences;
+import org.apache.wiki.util.ClassUtil;
 
 
 /**
@@ -316,58 +317,67 @@ public interface TemplateManager extends ModuleManager {
      *  rendered.  It's thus a good idea to make this request only once during the page life cycle.
      *
      *  @param ctx The current wiki context
-     *  @param type What kind of resource should be added?
+     *  @param type What kind of a request should be added?
      *  @param resource The resource to add.
      */
-    static void addResourceRequest( final Context ctx, final String type, final String resource ) {
-        HashMap< String, Vector< String > > resourcemap = ctx.getVariable( RESOURCE_INCLUDES );
-        if( resourcemap == null ) {
+    static void addResourceRequest(final Context ctx, final String type, final String resource) {
+        addResourceRequests(ctx, Collections.singletonList(type), Collections.singletonList(resource));
+    }
+
+    static void addResourceRequests(final Context ctx, final List<String> types, final List<String> resourcePaths) {
+        HashMap<String, Vector<String>> resourcemap = ctx.getVariable(RESOURCE_INCLUDES);
+        if (resourcemap == null) {
             resourcemap = new HashMap<>();
         }
 
-        // Module has to be treated as script for further processing of RESOURCE_INCLUDES variable
-        final String resourceType = type.equals(RESOURCE_SCRIPT_MODULE) ? RESOURCE_SCRIPT : type;
+        for (int i = 0; i < types.size(); i++) {
+            String type = types.get(i);
+            String resource = resourcePaths.get(i);
+            // Module has to be treated as script for further processing of RESOURCE_INCLUDES variable
+            final String resourceType = type.equals(RESOURCE_SCRIPT_MODULE) ? RESOURCE_SCRIPT : type;
 
-        Vector< String > resources = resourcemap.get( resourceType );
-        if( resources == null ) {
-            resources = new Vector<>();
-        }
-        String resolvedResource = resource;
-        if( Strings.CS.startsWith( resource, "engine://" ) ) {
-            final String val = ctx.getEngine().getWikiProperties().getProperty( resource.substring( 9 ) ); // "engine//:".length() == 9
-            if( StringUtils.isNotBlank( val ) ) {
-                resolvedResource = val;
+            Vector<String> resources = resourcemap.get(resourceType);
+            if (resources == null) {
+                resources = new Vector<>();
             }
+            String resolvedResource = resource;
+            if( StringUtils.startsWith( resource, "engine://" ) ) {
+                final String val = ctx.getEngine().getWikiProperties().getProperty( resource.substring( 9 ) ); // "engine//:".length() == 9
+                if( StringUtils.isNotBlank( val ) ) {
+                    resolvedResource = val;
+                }
+            }
+
+            String resourceString = null;
+            switch (type) {
+                case RESOURCE_SCRIPT_MODULE:
+                    resourceString = "<script type='module' src='" + resource + "'></script>";
+                    break;
+                case RESOURCE_SCRIPT:
+                    resourceString = "<script type='text/javascript' src='" + resolvedResource + "'></script>";
+                    break;
+                case RESOURCE_STYLESHEET:
+                    resourceString = "<link rel='stylesheet' type='text/css' href='" + resolvedResource + "' />";
+                    break;
+                case RESOURCE_INLINECSS:
+                    resourceString = "<style type='text/css'>\n" + resolvedResource + "\n</style>\n";
+                    break;
+                case RESOURCE_JSFUNCTION:
+                case RESOURCE_HTTPHEADER:
+                    resourceString = resolvedResource;
+                    break;
+            }
+
+            if (resourceString != null) {
+                resources.add(resourceString);
+            }
+
+            LoggerFactory.getLogger(TemplateManager.class).debug("Request to add a resource: " + resourceString);
+
+            resourcemap.put(resourceType, resources);
         }
 
-        String resourceString = null;
-        switch( type ) {
-        case RESOURCE_SCRIPT_MODULE:
-            resourceString = "<script type='module' src='" + resource + "'></script>";
-            break;
-        case RESOURCE_SCRIPT:
-            resourceString = "<script type='text/javascript' src='" + resolvedResource + "'></script>";
-            break;
-        case RESOURCE_STYLESHEET:
-            resourceString = "<link rel='stylesheet' type='text/css' href='" + resolvedResource + "' />";
-            break;
-        case RESOURCE_INLINECSS:
-            resourceString = "<style type='text/css'>\n" + resolvedResource + "\n</style>\n";
-            break;
-        case RESOURCE_JSFUNCTION:
-        case RESOURCE_HTTPHEADER:
-            resourceString = resolvedResource;
-            break;
-        }
-
-        if( resourceString != null ) {
-            resources.add( resourceString );
-        }
-
-        LoggerFactory.getLogger( TemplateManager.class ).debug( "Request to add a resource: {}", resourceString );
-
-        resourcemap.put(resourceType, resources );
-        ctx.setVariable( RESOURCE_INCLUDES, resourcemap );
+        ctx.setVariable(RESOURCE_INCLUDES, resourcemap);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -1179,9 +1179,14 @@
   </ciManagement>
 
   <distributionManagement>
+    <snapshotRepository>
+      <id>des-snapshots-public</id>
+      <name>denkbares Public Snapshots Repository</name>
+      <url>https://repo.denkbares.com/snapshots-public/</url>
+    </snapshotRepository>
     <repository>
       <id>des-releases-public</id>
-      <name>Denkbares Public Releases Repository</name>
+      <name>denkbares Public Releases Repository</name>
       <url>https://repo.denkbares.com/releases-public/</url>
     </repository>
   </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1177,4 +1177,12 @@
     <system>Jenkins</system>
     <url>https://builds.apache.org/job/JSPWiki</url>
   </ciManagement>
+
+  <distributionManagement>
+    <repository>
+      <id>des-releases-public</id>
+      <name>Denkbares Public Releases Repository</name>
+      <url>https://repo.denkbares.com/releases-public/</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1178,6 +1178,21 @@
     <url>https://builds.apache.org/job/JSPWiki</url>
   </ciManagement>
 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <checksumPolicy>ignore</checksumPolicy>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <id>des-repo-public</id>
+      <name>Denkbares Public Repository</name>
+      <url>https://repo.denkbares.com/repo-public/</url>
+    </repository>
+  </repositories>
+
   <distributionManagement>
     <snapshotRepository>
       <id>des-snapshots-public</id>


### PR DESCRIPTION
Small feature/infra clusters ported by `cherry-pick -x`:

- **IndexPlugin** (3 commits): ignore page-name prefixes; PageIndex fix; use the fixed `getAllPages` (relies on the provider subsystem already merged). Logger aligned to the 3.0 base (`LOG`).
- **TemplateManager** (1 commit): batch `addResourceRequests` so js/css resources are appended in a single request; keeps the base's `engine://` resource resolution. Adapted to jakarta.
- **Build infra** (3 commits): denkbares `distributionManagement` (releases/snapshots) + public `repositories`.

Two fork commits were empty against the 3.0 base (their net was already applied) and are recorded as superseded.

Green locally except the pre-existing `GroupPermissionTest.testImpliesMember` (macOS/Zulu only; passes on CI).