### PR TITLE
Port fork features surfaced by the final tree-audit

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
@@ -367,6 +367,14 @@ public class WikiEngine implements Engine {
     void createAndFindWorkingDirectory( final Properties props ) throws WikiException {
         m_workDir = TextUtil.getStringProperty( props, PROP_WORKDIR, null );
 
+        if( m_workDir == null ) {
+            m_workDir = System.getProperty( "java.io.tmpdir", "." );
+            final String baseDirName = new File( TextUtil.getStringProperty( props, "var.basedir", "default" ) ).getName();
+            final String baseDirSuffix = baseDirName.substring( 0, Math.min( baseDirName.length(), 10 ) ).replaceAll( "\\h+", "_" ); // avoid long paths
+            final String appName = TextUtil.getStringProperty( props, PROP_APPNAME, m_appid ).replaceAll( "\\h+", "_" );
+            m_workDir += File.separator + Release.APPNAME + "-" + appName + "-" + baseDirSuffix;
+        }
+
         final File f = new File( m_workDir );
         try {
             f.mkdirs();

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthorizationManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthorizationManager.java
@@ -361,9 +361,11 @@ public class DefaultAuthorizationManager implements AuthorizationManager {
 
         // Ok, no luck---this must be a user principal
         final Principal[] principals;
+        final UserProfile profile;
         final UserDatabase db = m_engine.getManager( UserManager.class ).getUserDatabase();
         try {
-           principals = db.getPrincipals( name );
+           profile = db.find( name );
+           principals = db.getPrincipals( profile.getLoginName() );
            for( final Principal value : principals ) {
                principal = value;
                if( principal.getName().equals( name ) ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
@@ -47,9 +47,14 @@ import java.nio.file.Files;
 import java.security.Principal;
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.SortedSet;
@@ -93,9 +98,18 @@ public class XMLUserDatabase extends AbstractUserDatabase {
     private static final String UID               = "uid";
     private static final String USER_TAG          = "user";
     private static final String WIKI_NAME         = "wikiName";
-    private static final String DATE_FORMAT       = "yyyy.MM.dd 'at' HH:mm:ss:SSS z";
+    private static final DateTimeFormatter DATE_FORMAT_EN = newFormatter( Locale.ENGLISH ).withZone( ZoneId.systemDefault() );
+    private static final List< DateTimeFormatter > FORMATTERS = List.of(
+            newFormatter( Locale.getDefault() ),
+            newFormatter( Locale.ENGLISH ),
+            newFormatter( Locale.GERMAN )
+    );
     private Document            c_dom;
     private File                c_file;
+
+    private static DateTimeFormatter newFormatter( final Locale locale ) {
+        return DateTimeFormatter.ofPattern( "yyyy.MM.dd 'at' HH:mm:ss:SSS z", locale );
+    }
     private int m_passwordReusedCount = -1;
 
     /** {@inheritDoc} */
@@ -389,10 +403,9 @@ public class XMLUserDatabase extends AbstractUserDatabase {
         for( int i = 0; i < users.getLength(); i++ ) {
             final Element user = ( Element )users.item( i );
             if( user.getAttribute( LOGIN_NAME ).equals( loginName ) ) {
-                final DateFormat c_format = new SimpleDateFormat( DATE_FORMAT );
                 final Date modDate = new Date( System.currentTimeMillis() );
                 setAttribute( user, LOGIN_NAME, newName );
-                setAttribute( user, LAST_MODIFIED, c_format.format( modDate ) );
+                setAttribute( user, LAST_MODIFIED, DATE_FORMAT_EN.format( modDate.toInstant() ) );
                 profile.setLoginName( newName );
                 profile.setLastModified( modDate );
                 break;
@@ -413,7 +426,6 @@ public class XMLUserDatabase extends AbstractUserDatabase {
 
         checkForRefresh();
 
-        final DateFormat c_format = new SimpleDateFormat( DATE_FORMAT );
         final String index = profile.getLoginName();
         final NodeList users = c_dom.getElementsByTagName( USER_TAG );
         Element user = IntStream.range(0, users.getLength()).mapToObj(i -> (Element) users.item(i)).filter(currentUser -> currentUser.getAttribute(LOGIN_NAME).equals(index)).findFirst().orElse(null);
@@ -427,7 +439,7 @@ public class XMLUserDatabase extends AbstractUserDatabase {
             LOG.info( "Creating new user " + index );
             user = c_dom.createElement( USER_TAG );
             c_dom.getDocumentElement().appendChild( user );
-            setAttribute( user, CREATED, c_format.format( profile.getCreated() ) );
+            setAttribute( user, CREATED, DATE_FORMAT_EN.format( profile.getCreated().toInstant() ) );
             isNew = true;
         } else {
             // To update existing user node, delete old attributes first...
@@ -438,13 +450,13 @@ public class XMLUserDatabase extends AbstractUserDatabase {
         }
 
         setAttribute( user, UID, profile.getUid() );
-        setAttribute( user, LAST_MODIFIED, c_format.format( modDate ) );
+        setAttribute( user, LAST_MODIFIED, DATE_FORMAT_EN.format( modDate.toInstant() ) );
         setAttribute( user, LOGIN_NAME, profile.getLoginName() );
         setAttribute( user, FULL_NAME, profile.getFullname() );
         setAttribute( user, WIKI_NAME, profile.getWikiName() );
         setAttribute( user, EMAIL, profile.getEmail() );
         final Date lockExpiry = profile.getLockExpiry();
-        setAttribute( user, LOCK_EXPIRY, lockExpiry == null ? "" : c_format.format( lockExpiry ) );
+        setAttribute( user, LOCK_EXPIRY, lockExpiry == null ? "" : DATE_FORMAT_EN.format( lockExpiry.toInstant() ) );
 
         // Hash and save the new password if it's different from old one
         final String newPassword = profile.getPassword();
@@ -595,8 +607,7 @@ public class XMLUserDatabase extends AbstractUserDatabase {
      */
     private Date parseDate( final UserProfile profile, final String date ) {
         try {
-            final DateFormat c_format = new SimpleDateFormat( DATE_FORMAT );
-            return c_format.parse( date );
+            return parseDate( date );
         } catch( final ParseException e ) {
             try {
                 return DateFormat.getDateTimeInstance().parse( date );
@@ -606,6 +617,19 @@ public class XMLUserDatabase extends AbstractUserDatabase {
             }
         }
         return null;
+    }
+
+    public Date parseDate( final String dateStr ) throws ParseException {
+        for( final DateTimeFormatter formatter : FORMATTERS ) {
+            try {
+                // Parse to ZonedDateTime and convert to legacy java.util.Date
+                final ZonedDateTime zdt = ZonedDateTime.parse( dateStr, formatter );
+                return Date.from( zdt.toInstant() );
+            } catch( final DateTimeParseException ignored ) {
+                // Try next format
+            }
+        }
+        return DateFormat.getDateTimeInstance().parse( dateStr );
     }
 
     /**
@@ -632,22 +656,14 @@ public class XMLUserDatabase extends AbstractUserDatabase {
             final String loginName = user.getAttribute( LOGIN_NAME );
             String created = user.getAttribute( CREATED );
             String modified = user.getAttribute( LAST_MODIFIED );
-            final DateFormat c_format = new SimpleDateFormat( DATE_FORMAT );
             try {
-                created = c_format.format( c_format.parse( created ) );
-                modified = c_format.format( c_format.parse( modified ) );
+                created = DATE_FORMAT_EN.format( parseDate( created ).toInstant() );
+                modified = DATE_FORMAT_EN.format( parseDate( modified ).toInstant() );
                 user.setAttribute( CREATED, created );
                 user.setAttribute( LAST_MODIFIED, modified );
             } catch( final ParseException e ) {
-                try {
-                    created = c_format.format( DateFormat.getDateTimeInstance().parse( created ) );
-                    modified = c_format.format( DateFormat.getDateTimeInstance().parse( modified ) );
-                    user.setAttribute( CREATED, created );
-                    user.setAttribute( LAST_MODIFIED, modified );
-                } catch( final ParseException e2 ) {
-                    LOG.warn( "Could not parse 'created' or 'lastModified' attribute for profile '" + loginName + "'."
-                            + " It may have been tampered with." );
-                }
+                LOG.warn( "Could not parse 'created' or 'lastModified' attribute for profile '" + loginName + "'."
+                        + " It may have been tampered with." );
             }
         }
     }

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/LinkTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/LinkTag.java
@@ -19,6 +19,8 @@
 package org.apache.wiki.tags;
 
 import org.slf4j.LoggerFactory;
+
+import static org.apache.wiki.utils.WikiPageUtils.getJarVersion;
 import org.slf4j.Logger;
 import org.apache.wiki.api.core.Attachment;
 import org.apache.wiki.api.core.ContextEnum;
@@ -171,6 +173,7 @@ public class LinkTag extends WikiLinkTag implements ParamHandler, BodyTag {
     private String figureOutURL() throws ProviderException {
         String url = null;
         final Engine engine = m_wikiContext.getEngine();
+        boolean appendVersion = false;
 
         if( m_pageName == null ) {
             final Page page = m_wikiContext.getPage();
@@ -183,11 +186,14 @@ public class LinkTag extends WikiLinkTag implements ParamHandler, BodyTag {
             final String params = addParamsForRecipient( null, m_containedParams );
             final String template = engine.getTemplateDir();
             url = engine.getURL( ContextEnum.PAGE_NONE.getRequestContext(), "templates/"+template+"/"+m_templatefile, params );
+            appendVersion = true;
         } else if( m_jsp != null ) {
             final String params = addParamsForRecipient( null, m_containedParams );
             //url = m_wikiContext.getURL( ContextEnum.PAGE_NONE.getRequestContext(), m_jsp, params );
             url = engine.getURL( ContextEnum.PAGE_NONE.getRequestContext(), m_jsp, params );
+            appendVersion = true;
         } else if( m_ref != null ) {
+            appendVersion = true;
             final int interwikipoint;
             if( new LinkParsingOperations( m_wikiContext ).isExternalLink(m_ref) ) {
                 url = m_ref;
@@ -256,6 +262,12 @@ public class LinkTag extends WikiLinkTag implements ParamHandler, BodyTag {
         } else {
             final String page = engine.getFrontPage();
             url = makeBasicURL( m_context, page, null );
+        }
+
+        final String version = m_version == null ? getJarVersion() : m_version;
+        if( appendVersion && url != null && !"version".contains( url ) && !url.endsWith( "/" ) && !url.endsWith( ".jsp" ) ) {
+            final String appendChar = url.contains( "?" ) ? "&" : "?";
+            url += appendChar + "version=" + version;
         }
 
         return url;

--- a/jspwiki-main/src/main/java/org/apache/wiki/utils/WikiPageUtils.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/utils/WikiPageUtils.java
@@ -4,11 +4,16 @@
 
 package org.apache.wiki.utils;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
 import org.apache.wiki.api.core.Engine;
 import org.apache.wiki.api.core.Page;
 import org.apache.wiki.api.exceptions.ProviderException;
 import org.apache.wiki.api.exceptions.WikiException;
 import org.apache.wiki.pages.PageManager;
+import org.apache.wiki.tags.LinkTag;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Antonia Heyder (denkbares GmbH)
@@ -17,6 +22,7 @@ import org.apache.wiki.pages.PageManager;
 public class WikiPageUtils {
 	private static final String invalidCharsRegex = "[\\\\/|;:<>?*+]";
 	private static final String invalidChars = "\\/|;:<>?*+";
+	private static String m_jar_version;
 
 	public static void checkDuplicatePagesCaseSensitive(Engine engine, String pageName) throws ProviderException {
 
@@ -31,5 +37,28 @@ public class WikiPageUtils {
 		if (renameTo.matches(".*" + invalidCharsRegex + ".*")) {
 			throw new WikiException("Page name contains prohibited characters (" + invalidChars + ").");
 		}
+	}
+
+
+	public static String getJarVersion() {
+		if (m_jar_version != null) return m_jar_version;
+		Class<? extends LinkTag> clazz = LinkTag.class;
+		try {
+			// Hole den URL zur .class-Datei der Klasse
+			URL classUrl = clazz.getResource(clazz.getSimpleName() + ".class");
+			if (classUrl != null) {
+				URLConnection connection = classUrl.openConnection();
+				long lastModified = connection.getLastModified();
+				if (lastModified > 0) {
+					m_jar_version = String.valueOf(lastModified);
+				}
+			}
+		} catch (IOException e) {
+			LoggerFactory.getLogger(clazz).warn("Couldn't get jar version, using current date", e);
+		}
+		if (m_jar_version == null) {
+			m_jar_version = String.valueOf(System.currentTimeMillis());
+		}
+		return m_jar_version;
 	}
 }

--- a/jspwiki-main/src/test/java/org/apache/wiki/auth/AuthorizationManagerTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/auth/AuthorizationManagerTest.java
@@ -519,6 +519,7 @@ public class AuthorizationManagerTest {
             Assertions.fail( "Failed save: " + e.getLocalizedMessage() );
         }
         Assertions.assertEquals( new WikiPrincipal( "authmanagertest",  WikiPrincipal.LOGIN_NAME ), m_auth.resolvePrincipal( "authmanagertest" ) );
+        // Resolution by full/wiki name requires the 2.x ACL logic (jspwiki.use2XAclLogic), which is off by default in 3.0:
         //Assertions.assertEquals( new WikiPrincipal( "AuthorizationManagerTest User", WikiPrincipal.FULL_NAME ), m_auth.resolvePrincipal( "AuthorizationManagerTest User" ) );
         //Assertions.assertEquals( new WikiPrincipal( "AuthorizationManagerTestUser", WikiPrincipal.WIKI_NAME ), m_auth.resolvePrincipal( "AuthorizationManagerTestUser" ) );
         try

--- a/jspwiki-main/src/test/java/org/apache/wiki/providers/BasicAttachmentProviderCreationDateTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/providers/BasicAttachmentProviderCreationDateTest.java
@@ -1,0 +1,131 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.providers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Properties;
+
+/**
+ * Tests for the attachment creation-date batch ({@link BasicAttachmentProvider#ensureAttachmentCreationDates}):
+ * persisting a date per version, the per-version restore from {@code restore-creation-dates.properties}, and the
+ * precedence of an already-persisted date. Engine-free: it drives the provider's batch method directly.
+ */
+public class BasicAttachmentProviderCreationDateTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	public void testRestoreAppliesPerVersionAndFsKeptWithoutRestore() throws Exception {
+		final File attDir = attachmentDir("SomePage-att", "diagram.png-dir");
+		writeVersion(attDir, "1.png", "2020-01-01T00:00:00"); // file system newer than restore -> restore wins
+		writeVersion(attDir, "2.png", "2021-02-02T00:00:00"); // no restore entry -> keep file system date
+
+		final Properties restore = new Properties();
+		restore.setProperty("SomePage-att/diagram.png-dir#1", "2016-05-05T05:05:05");
+
+		final boolean changed = new BasicAttachmentProvider().ensureAttachmentCreationDates("SomePage-att", attDir, restore);
+		Assertions.assertTrue(changed, "dates should be written");
+
+		final Properties props = readProperties(attDir);
+		assertSameSecond(millis("2016-05-05T05:05:05"), props.getProperty("1.date"), "version 1 restored from backup");
+		assertSameSecond(millis("2021-02-02T00:00:00"), props.getProperty("2.date"), "version 2 keeps file system date");
+	}
+
+	@Test
+	public void testFileSystemDateKeptWhenOlderThanRestore() throws Exception {
+		final File attDir = attachmentDir("SomePage-att", "diagram.png-dir");
+		writeVersion(attDir, "1.png", "2015-01-01T00:00:00"); // older than restore -> keep file system date
+
+		final Properties restore = new Properties();
+		restore.setProperty("SomePage-att/diagram.png-dir#1", "2020-06-15T10:00:00");
+
+		new BasicAttachmentProvider().ensureAttachmentCreationDates("SomePage-att", attDir, restore);
+
+		assertSameSecond(millis("2015-01-01T00:00:00"), readProperties(attDir).getProperty("1.date"),
+				"file system date must be kept when it is older than the restore date");
+	}
+
+	@Test
+	public void testExistingDateWinsOverRestore() throws Exception {
+		final File attDir = attachmentDir("SomePage-att", "diagram.png-dir");
+		writeVersion(attDir, "1.png", "2020-01-01T00:00:00");
+
+		// pre-existing persisted date (e.g. written at upload time); must not be overwritten
+		final Properties existing = new Properties();
+		existing.setProperty("1.date", "2012-12-12T12:12:12");
+		try (final OutputStream out = Files.newOutputStream(new File(attDir, BasicAttachmentProvider.PROPERTY_FILE).toPath())) {
+			existing.store(out, "test");
+		}
+
+		final Properties restore = new Properties();
+		restore.setProperty("SomePage-att/diagram.png-dir#1", "2016-05-05T05:05:05");
+
+		final boolean changed = new BasicAttachmentProvider().ensureAttachmentCreationDates("SomePage-att", attDir, restore);
+		Assertions.assertFalse(changed, "an already persisted date must not be changed");
+		Assertions.assertEquals("2012-12-12T12:12:12", readProperties(attDir).getProperty("1.date"));
+	}
+
+	// ----------------------------------------------------------------------------------------------------
+
+	private File attachmentDir(final String pageAttName, final String attachmentDirName) {
+		final File dir = new File(new File(tempDir, pageAttName), attachmentDirName);
+		dir.mkdirs();
+		return dir;
+	}
+
+	private void writeVersion(final File attachmentDir, final String fileName, final String localDateTime) throws IOException {
+		final File file = new File(attachmentDir, fileName);
+		Files.write(file.toPath(), ("content of " + fileName).getBytes(StandardCharsets.UTF_8));
+		file.setLastModified(millis(localDateTime));
+	}
+
+	private Properties readProperties(final File attachmentDir) throws IOException {
+		final Properties props = new Properties();
+		try (final InputStream in = new FileInputStream(new File(attachmentDir, BasicAttachmentProvider.PROPERTY_FILE))) {
+			props.load(in);
+		}
+		return props;
+	}
+
+	private static long millis(final String localDateTime) {
+		return LocalDateTime.parse(localDateTime).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+	}
+
+	private static void assertSameSecond(final long expectedMillis, final String storedValue, final String message) {
+		final Instant expected = Instant.ofEpochMilli(expectedMillis).truncatedTo(ChronoUnit.SECONDS);
+		final Instant actual = Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(storedValue)).truncatedTo(ChronoUnit.SECONDS);
+		Assertions.assertEquals(expected, actual, message + " (stored=" + storedValue + ")");
+	}
+}

--- a/jspwiki-main/src/test/java/org/apache/wiki/providers/RestoreCreationDatesFromZipTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/providers/RestoreCreationDatesFromZipTest.java
@@ -1,0 +1,173 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.providers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class RestoreCreationDatesFromZipTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	public void testChoosePageDirectoryWithOneWrappingFolder() {
+		// the common case: one folder in the ZIP, the wiki pages inside it, plus OLD/ versions deeper down
+		final String dir = RestoreCreationDatesFromZip.choosePageDirectory(Arrays.asList(
+				"mybackup/Main.txt",
+				"mybackup/SecondPage.txt",
+				"mybackup/OLD/Main/1.txt",
+				"mybackup/OLD/Main/2.txt"));
+		Assertions.assertEquals("mybackup/", dir);
+	}
+
+	@Test
+	public void testChoosePageDirectoryAtRoot() {
+		final String dir = RestoreCreationDatesFromZip.choosePageDirectory(Arrays.asList(
+				"Main.txt", "SecondPage.txt", "OLD/Main/1.txt"));
+		Assertions.assertEquals("", dir);
+	}
+
+	@Test
+	public void testChoosePageDirectoryWithDeepNesting() {
+		final String dir = RestoreCreationDatesFromZip.choosePageDirectory(Arrays.asList(
+				"export/2024/wikicontent/Main.txt",
+				"export/2024/wikicontent/SecondPage.txt",
+				"export/2024/wikicontent/OLD/Main/1.txt"));
+		Assertions.assertEquals("export/2024/wikicontent/", dir);
+	}
+
+	@Test
+	public void testBuildPageEntriesIncludesAllVersions() {
+		final Map<String, Long> times = new LinkedHashMap<>();
+		times.put("backup/Main.txt", millis("2018-04-12T09:31:00"));        // latest version of Main
+		times.put("backup/SecondPage.txt", millis("2019-01-02T03:04:05"));  // latest version of SecondPage
+		times.put("backup/OLD/Main/1.txt", millis("2010-01-01T00:00:00"));  // older version of Main
+
+		final String dir = RestoreCreationDatesFromZip.choosePageDirectory(new ArrayList<>(times.keySet()));
+		final SortedMap<String, String> entries = RestoreCreationDatesFromZip.buildPageEntries(times, dir);
+
+		Assertions.assertEquals(Set.of("Main#latest", "SecondPage#latest", "Main#1"), entries.keySet(),
+				"current page files plus every OLD version");
+		assertSameSecond(millis("2018-04-12T09:31:00"), entries.get("Main#latest"));
+		assertSameSecond(millis("2019-01-02T03:04:05"), entries.get("SecondPage#latest"));
+		assertSameSecond(millis("2010-01-01T00:00:00"), entries.get("Main#1"));
+	}
+
+	@Test
+	public void testReadFromRealZipNestedAndIgnoresNonTxt() throws IOException {
+		final Map<String, Long> zipEntries = new LinkedHashMap<>();
+		zipEntries.put("mybackup/Main.txt", millis("2018-04-12T09:31:00"));
+		zipEntries.put("mybackup/My%20Page.txt", millis("2017-07-07T07:07:07"));
+		zipEntries.put("mybackup/Main.properties", millis("2021-12-12T12:12:12")); // must be ignored
+		zipEntries.put("mybackup/OLD/Main/1.txt", millis("2010-01-01T00:00:00")); // older version of Main
+		final File zip = createZip(zipEntries);
+
+		final Map<String, Long> txtTimes = RestoreCreationDatesFromZip.readTxtEntryTimes(zip);
+		Assertions.assertEquals(Set.of("mybackup/Main.txt", "mybackup/My%20Page.txt", "mybackup/OLD/Main/1.txt"),
+				txtTimes.keySet(), "only .txt entries are read");
+
+		final String dir = RestoreCreationDatesFromZip.choosePageDirectory(new ArrayList<>(txtTimes.keySet()));
+		Assertions.assertEquals("mybackup/", dir);
+
+		final SortedMap<String, String> entries = RestoreCreationDatesFromZip.buildPageEntries(txtTimes, dir);
+		Assertions.assertEquals(Set.of("Main#latest", "My%20Page#latest", "Main#1"), entries.keySet());
+		assertSameSecond(millis("2018-04-12T09:31:00"), entries.get("Main#latest"));
+		assertSameSecond(millis("2017-07-07T07:07:07"), entries.get("My%20Page#latest"));
+		assertSameSecond(millis("2010-01-01T00:00:00"), entries.get("Main#1"));
+	}
+
+	@Test
+	public void testMangledKeyMatchesProviderLookup() {
+		// The ZIP stores wiki pages under their mangled (URL-encoded) file names, e.g. "CC1182808+Memo+1.txt",
+		// so the generated restore key is "CC1182808+Memo+1". VersioningFileProvider looks the restore date up
+		// via mangleName(pageName) first, which must reproduce exactly that encoded form for the lookup to hit.
+		final VersioningFileProvider provider = new VersioningFileProvider();
+		provider.m_encoding = AbstractFileProvider.DEFAULT_ENCODING;
+		Assertions.assertEquals("CC1182808+Memo+1", provider.mangleName("CC1182808 Memo 1"),
+				"mangleName must reproduce the URL-encoded file-name stem used as the restore key");
+	}
+
+	@Test
+	public void testAttachmentCreationDatesFromZip() throws IOException {
+		final Map<String, Long> zipEntries = new LinkedHashMap<>();
+		zipEntries.put("mybackup/Main.txt", millis("2018-04-12T09:31:00"));
+		zipEntries.put("mybackup/Main-att/diagram.png-dir/1.png", millis("2016-01-02T03:04:05")); // creation
+		zipEntries.put("mybackup/Main-att/diagram.png-dir/2.png", millis("2020-01-02T03:04:05")); // later version
+		zipEntries.put("mybackup/Main-att/diagram.png-dir/attachment.properties", millis("2021-01-01T00:00:00")); // ignored
+		final File zip = createZip(zipEntries);
+
+		final Map<String, Long> all = RestoreCreationDatesFromZip.readAllEntryTimes(zip);
+		final String pageDir = RestoreCreationDatesFromZip.choosePageDirectory(
+				new ArrayList<>(RestoreCreationDatesFromZip.readTxtEntryTimes(zip).keySet()));
+		Assertions.assertEquals("mybackup/", pageDir);
+
+		final SortedMap<String, String> attachments = RestoreCreationDatesFromZip.buildAttachmentEntries(all, pageDir);
+		Assertions.assertEquals(Set.of("Main-att/diagram.png-dir#1", "Main-att/diagram.png-dir#2"), attachments.keySet(),
+				"every attachment version, but not the property file");
+		assertSameSecond(millis("2016-01-02T03:04:05"), attachments.get("Main-att/diagram.png-dir#1"));
+		assertSameSecond(millis("2020-01-02T03:04:05"), attachments.get("Main-att/diagram.png-dir#2"));
+	}
+
+	// ----------------------------------------------------------------------------------------------------
+
+	private File createZip(final Map<String, Long> entries) throws IOException {
+		final File zip = new File(tempDir, "backup.zip");
+		try (final ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zip))) {
+			for (final Map.Entry<String, Long> e : entries.entrySet()) {
+				final ZipEntry entry = new ZipEntry(e.getKey());
+				entry.setLastModifiedTime(FileTime.fromMillis(e.getValue()));
+				zos.putNextEntry(entry);
+				zos.write(("content of " + e.getKey()).getBytes(StandardCharsets.UTF_8));
+				zos.closeEntry();
+			}
+		}
+		return zip;
+	}
+
+	private static long millis(final String localDateTime) {
+		return LocalDateTime.parse(localDateTime).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+	}
+
+	private static void assertSameSecond(final long expectedMillis, final String actualValue) {
+		final Instant expected = Instant.ofEpochMilli(expectedMillis).truncatedTo(ChronoUnit.SECONDS);
+		final Instant actual = OffsetDateTime.parse(actualValue).toInstant().truncatedTo(ChronoUnit.SECONDS);
+		Assertions.assertEquals(expected, actual, "value " + actualValue);
+	}
+}

--- a/jspwiki-war/src/main/scripts/moo-extend/Element.Extend.js
+++ b/jspwiki-war/src/main/scripts/moo-extend/Element.Extend.js
@@ -245,40 +245,48 @@ Element.implement({
         var self = this,
             modal = self.getElement(selector);
 
-        function doSelfEvent(event){
-
-            modal.addClass( "active" );
-            document.body.addClass( "show-modal" );
-            event.preventDefault(); //postpone the click event
+        function onClick(event){
+            event.preventDefault();
+            modal.openModal( function(){
+                self.removeEvent("click", onClick).click();
+            });
         }
 
-        function doModalEvent(){
+        if( modal ){ self.addEvent( "click" , onClick); }
 
-            modal.removeClass( "active" );
-            document.body.removeClass( "show-modal" );
+    },
+    openModal: function( callback ){
 
-            if( this.match(".btn-success") ){
-                self.removeEvent( "click" , doSelfEvent ).click();
-            }
+        var modal = this,
+            init = "modal-initialized";
+
+        function clickModal(event){
+
+            modal.ifClass(!event, "active");
+            document.body.ifClass(!event, "show-modal");
+            if( event && this.matches(".btn-success") ){ callback(); }
+
         }
 
-        if( modal ){
-
-            //build a pretty modal dialog
-            if( !modal.getElement("> modal-footer") ){
-                modal.grab([
-                    "div.modal-footer", [
-                        "button.btn.btn-success", { text: "Confirm" },  //FIXME: i18n
-                        "button.btn.btn-danger", { text: "Cancel" }
+        if( !modal.getElement(".btn.btn-success") ){
+            //add buttons at the bottom of the modal dialog
+            modal.appendChild([
+                "div.modal-footer", [
+                    "button.btn.btn-success", { text: "dialog.confirm".localize() },
+                    "button.btn.btn-danger", { text: "dialog.cancel".localize() }
                     ]
                 ].slick());
-            }
+        }
+
+        if( !modal.hasClass(init) ){
+
             //move it just before the backdrop element for easy css styling
             modal.inject( document.getBackdrop(), "before" )
-                 .addEvent( "click:relay(.btn)",  doModalEvent );
-
-            self.addEvent( "click" , doSelfEvent );
+                 .addClass( init )
+                 .addEvent("click:relay(.btn)",  clickModal);
         }
+
+        clickModal(false); //and now show the modal
     },
 
     /*

--- a/jspwiki-war/src/main/scripts/wiki/Wiki.js
+++ b/jspwiki-war/src/main/scripts/wiki/Wiki.js
@@ -542,7 +542,7 @@ var Wiki = {
     cleanPageName: function( pagename ){
 
         //\w is short for [A-Z_a-z0-9_]
-        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD()&+,\-=.$ ]/g, "");
+        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD()&+,\-=.$/ ]/g, "");
 
     },
 
@@ -675,7 +675,8 @@ var Wiki = {
             new Request({
                 url: wiki.XHRHtml2Markup,
                 data: {
-                    htmlPageText: getContent()
+                    htmlPageText: getContent(),
+                    'X-XSRF-TOKEN': wiki.CsrfProtection
                 },
                 onSuccess: function(responseText){
                     preview( responseText.trim() );
@@ -837,7 +838,7 @@ var Wiki = {
                     throw new Error("Wiki rpc error: " + error);
                 }
 
-            }).send( "params=" + params );
+            }).send( "X-XSRF-TOKEN=" + this.CsrfProtection + "&params=" + params );
 
         }
 

--- a/jspwiki-war/src/main/webapp/templates/default/WorkflowContent.jsp
+++ b/jspwiki-war/src/main/webapp/templates/default/WorkflowContent.jsp
@@ -51,6 +51,7 @@
 					<thead><%-- 5/45/15/15/20--%>
 					<th scope="col"><fmt:message key="workflow.id"/></th>
 					<th scope="col"><fmt:message key="workflow.item"/></th>
+					<th scope="col"><fmt:message key="workflow.requester"/></th>
 					<th scope="col"><fmt:message key="workflow.startTime"/></th>
 					<th scope="col"><fmt:message key="workflow.actions"/></th>
 					</thead>
@@ -66,6 +67,9 @@
 								New user profile
 							</td>
 
+								<%-- Requester --%>
+							<td>${activeWorkflows[decision.workflowId].owner.name}</td>
+
 								<%-- When did the actor start this step? --%>
 							<td>
 								<fmt:formatDate value="${decision.startTime}" pattern="${prefs.DateFormat}"
@@ -77,6 +81,7 @@
 								<form action="<wiki:Link jsp='Workflow.jsp' format='url'/>"
 									  id="decision.${decision.id}"
 									  method="POST" accept-charset="UTF-8">
+									<wiki:CsrfProtection/>
 									<input type="hidden" name="action" value="decide"/>
 									<input type="hidden" name="id" value="${decision.id}"/>
 									<c:forEach var="outcome" items="${decision.availableOutcomes}">
@@ -158,6 +163,7 @@
 								<form id="workflow.${workflow.id}"
 									  action="<wiki:Link jsp='Workflow.jsp' format='url'/>"
 									  method="POST" accept-charset="UTF-8">
+									<wiki:CsrfProtection/>
 									<input class="btn btn-danger btn-xs" type="submit" name="submit"
 										   value="<fmt:message key="outcome.step.abort" />"/>
 									<input type="hidden" name="action" value="abort"/>

--- a/jspwiki-war/src/main/webapp/templates/default/commonheader.jsp
+++ b/jspwiki-war/src/main/webapp/templates/default/commonheader.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.apache.wiki.util.*" %>
 <%@ page import="org.apache.wiki.preferences.Preferences" %>
 <%@ page import="java.util.*" %>
+<%@ page import="org.apache.wiki.utils.WikiPageUtils" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <fmt:setLocale value="${prefs.Language}" />
@@ -148,9 +149,9 @@ String.I18N.PREFIX = "javascript.";
 <%-- SKINS : extra stylesheets, extra javascript --%>
 <c:if test='${(!empty prefs.SkinName) && (prefs.SkinName!="PlainVanilla") }'>
 <link rel="stylesheet" type="text/css" media="screen, projection, print"
-     href="<wiki:Link format='url' templatefile='skins/' /><c:out value='${prefs.SkinName}/skin.css' />" />
+     href="<wiki:Link format='url' templatefile='skins/' /><c:out value='${prefs.SkinName}/skin.css' /><%= "?version=" + WikiPageUtils.getJarVersion() %>" />
 <script type="text/javascript"
-         src="<wiki:Link format='url' templatefile='skins/' /><c:out value='${prefs.SkinName}/skin.js' />" ></script>
+         src="<wiki:Link format='url' templatefile='skins/' /><c:out value='${prefs.SkinName}/skin.js' /><%= "?version=" + WikiPageUtils.getJarVersion() %>" ></script>
 </c:if>
 
 <wiki:Include page="localheader.jsp"/>


### PR DESCRIPTION
The final tree-audit (parallel diff review of `knowwe-3.0` vs the fork tip) surfaced a handful of genuine fork features that hadn't been carried over by the cluster passes. This ports them:

- **WikiEngine** — default `jspwiki.workDir` to a tmpdir-derived path when the property is unset (avoids NPE/mkdirs failure).
- **XMLUserDatabase** — write dates locale-independently (English) and parse tolerantly across default/English/German locales via `DateTimeFormatter` (fixes German-locale-written user DBs failing to parse).
- **Cache-busting** — `WikiPageUtils.getJarVersion()` + `?version=` on `LinkTag` template/jsp/ref URLs and on the selected skin's css/js in `commonheader.jsp`.
- **DefaultAuthorizationManager.resolvePrincipal** — resolve users referenced by full/wiki name via `UserDatabase.find` (2.x ACL resolution; only affects behavior when `jspwiki.use2XAclLogic` is enabled, so 3.0's login-name default is unchanged).
- **Wiki.js** — allow `/` in cleaned page names (sub-wiki paths); send `X-XSRF-TOKEN` on the html-to-markup preview and RPC AJAX requests.
- **Element.Extend.js** — add the `openModal()` helper that `Wiki.js` already calls (the call was otherwise broken) with localized confirm/cancel.
- **WorkflowContent.jsp** — requester column + `<wiki:CsrfProtection/>` on the workflow forms.
- Ported the two fork tests whose production features are present but coverage was missing: `RestoreCreationDatesFromZipTest`, `BasicAttachmentProviderCreationDateTest`.

Everything else in the audit was an intended delta (jakarta/slf4j/coordinates, D1 diff-providers, D2 Captcha, D3 TestContainer, D4 xmlrpc relocation, D9 dark-skin, or features where knowwe-3.0 is already ahead of the fork).

Full reactor `package` builds green; `jspwiki-main` tests green except the pre-existing `GroupPermissionTest.testImpliesMember` (macOS/Zulu only; green on CI).