### PR TITLE
Restore upstream XML-RPC handling (dead source + PingWeblogsComFilter + dep)

### DIFF
--- a/jspwiki-main/pom.xml
+++ b/jspwiki-main/pom.xml
@@ -194,6 +194,11 @@
         </dependency>
 
         <dependency>
+            <groupId>xmlrpc</groupId>
+            <artifactId>xmlrpc</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>

--- a/jspwiki-main/src/main/java/org/apache/wiki/filters/PingWeblogsComFilter.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/filters/PingWeblogsComFilter.java
@@ -1,0 +1,117 @@
+/* 
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.  
+ */
+package org.apache.wiki.filters;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.ContextEnum;
+import org.apache.wiki.api.core.Engine;
+import org.apache.wiki.api.filters.BasePageFilter;
+import org.apache.xmlrpc.AsyncCallback;
+import org.apache.xmlrpc.XmlRpcClient;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Hashtable;
+import java.util.Properties;
+import java.util.Vector;
+
+/**
+ *  A very dumb class that pings weblogs.com on each save.  INTERNAL USE ONLY SO FAR! Look, but don't use as-is.
+ */
+// FIXME: Needs to figure out when only weblogs have been saved.
+// FIXME: rpc endpoint must be configurable
+// FIXME: Should really be settable per-page.
+// FIXME: Weblog name has been set to stone
+public class PingWeblogsComFilter extends BasePageFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger( PingWeblogsComFilter.class );
+
+    private String m_pingURL;
+
+    /**
+     *  The property name for the URL to ping.  Value is <tt>{@value}</tt>.
+     */
+    public static final String PROP_PINGURL = "pingurl";
+
+    /**
+     *  {@inheritDoc}
+     */
+    @Override
+    public void initialize( final Engine engine, final Properties props ) {
+        m_pingURL = props.getProperty( PROP_PINGURL, "http://rpc.weblogs.com/RPC2" );
+    }
+
+    /**
+     *  {@inheritDoc}
+     */
+    @Override
+    public void postSave( final Context context, final String pagecontent ) {
+        String blogName = context.getPage().getName();
+        final Engine engine   = context.getEngine();
+
+        final int blogentryTxt = blogName.indexOf("_blogentry_");
+        if( blogentryTxt == -1 ) {
+            return; // This is not a weblog entry.
+        }
+        
+        blogName = blogName.substring( 0, blogentryTxt );
+
+        if( blogName.equals( engine.getFrontPage() ) ) {
+            blogName = null;
+        }
+
+        try {
+            final XmlRpcClient xmlrpc = new XmlRpcClient(m_pingURL);
+            final Vector< String > params = new Vector<>();
+            params.addElement( "The Butt Ugly Weblog" ); // FIXME: Must be settable
+            params.addElement( engine.getURL( ContextEnum.PAGE_VIEW.getRequestContext(), blogName, null ) );
+
+            LOG.debug( "Pinging weblogs.com with URL: {}", engine.getURL( ContextEnum.PAGE_VIEW.getRequestContext(), blogName, null ) );
+
+            xmlrpc.executeAsync("weblogUpdates.ping", params, 
+                                new AsyncCallback() {
+                                    @Override
+                                    public void handleError( final Exception ex, final URL url, final String method ) {
+                                        LOG.error( "Unable to execute weblogs.com ping to URL: " + url.toString(), ex );
+                                    }
+
+                                    @Override
+                                    public void handleResult( final Object result, final URL url, final String method ) {
+                                        @SuppressWarnings("unchecked")
+                                        final Hashtable< String, Object > res = (Hashtable < String, Object > ) result;
+
+                                        final Boolean flerror = ( Boolean )res.get( "flerror" );
+                                        final String  msg     = ( String )res.get( "message" );
+
+                                        if( flerror ) {
+                                            LOG.error( "Failed to ping: " + msg );
+                                        }
+
+                                        LOG.info( "Weblogs.com has been pinged." );
+                                    }
+                                }
+                                );
+        } catch( final MalformedURLException e ) {
+            LOG.error("Malformed URL",e);
+        }
+    }
+
+}

--- a/jspwiki-war/src/main/webapp/WEB-INF/web.xml
+++ b/jspwiki-war/src/main/webapp/WEB-INF/web.xml
@@ -78,6 +78,8 @@
      <filter-name>WikiServletFilter</filter-name>
      <url-pattern>/attach/*</url-pattern>
      <url-pattern>/atom/*</url-pattern>
+     <url-pattern>/RPCU/</url-pattern>
+     <url-pattern>/RPC2/</url-pattern>
    </filter-mapping>
    <filter-mapping>
      <filter-name>WikiJSPFilter</filter-name>

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/AbstractRPCHandler.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/AbstractRPCHandler.java
@@ -1,0 +1,116 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.Engine;
+import org.apache.wiki.api.core.Page;
+import org.apache.wiki.auth.AuthorizationManager;
+import org.apache.wiki.auth.permissions.PagePermission;
+import org.apache.wiki.auth.permissions.WikiPermission;
+import org.apache.wiki.pages.PageManager;
+import org.apache.xmlrpc.AuthenticationFailed;
+
+import java.security.Permission;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.Vector;
+
+/**
+ *  Provides definitions for RPC handler routines.
+ *
+ *  @since 1.6.13
+ */
+
+public abstract class AbstractRPCHandler implements WikiRPCHandler {
+
+    /** Error code: no such page. */
+    public static final int ERR_NOPAGE       = 1;
+    public static final int ERR_NOPERMISSION = 2;
+
+    /** Link to a local wiki page. */
+    public static final String LINK_LOCAL    = "local";
+
+    /** Link to an external resource. */
+    public static final String LINK_EXTERNAL = "external";
+
+    /** This is an inlined image. */
+    public static final String LINK_INLINE   = "inline";
+
+    protected Engine m_engine;
+    protected Context m_context;
+
+    /** This is the currently implemented JSPWiki XML-RPC code revision. */
+    public static final int RPC_VERSION = 1;
+
+    @Override
+    public void initialize( final Context context ) {
+        m_context = context;
+        m_engine  = context.getEngine();
+    }
+
+    protected abstract Hashtable encodeWikiPage( Page p );
+
+    public Vector getRecentChanges( final Date since ) {
+        checkPermission( PagePermission.VIEW );
+        final Set< Page > pages = m_engine.getManager( PageManager.class ).getRecentChanges();
+        final Vector< Hashtable< ?, ? > > result = new Vector<>();
+
+        // Transform UTC into local time.
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( since );
+        cal.add( Calendar.MILLISECOND, cal.get( Calendar.ZONE_OFFSET ) +
+                  (cal.getTimeZone().inDaylightTime( since ) ? cal.get( Calendar.DST_OFFSET ) : 0 ) );
+
+        for( final Page page : pages ) {
+            if( page.getLastModified().after( cal.getTime() ) ) {
+                result.add( encodeWikiPage( page ) );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     *  Checks whether the current user has permission to perform the RPC action;
+     *  throws an exception if not allowed by {@link org.apache.wiki.auth.AuthorizationManager}.
+     *
+     *  @param perm the Permission to check
+     */
+    protected void checkPermission( final Permission perm ) {
+        final AuthorizationManager mgr = m_engine.getManager( AuthorizationManager.class );
+
+        if( mgr.checkPermission( m_context.getWikiSession(), perm ) ) {
+            return;
+        }
+
+        throw new AuthenticationFailed( "You have no access to this resource, o master" );
+    }
+
+    /**
+     *  Returns the current supported JSPWiki XML-RPC API.
+     */
+    public int getRPCVersionSupported() {
+        checkPermission( WikiPermission.LOGIN );
+        return RPC_VERSION;
+    }
+
+}

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/MetaWeblogHandler.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/MetaWeblogHandler.java
@@ -1,0 +1,328 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.apache.wiki.api.core.Attachment;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.ContextEnum;
+import org.apache.wiki.api.core.Engine;
+import org.apache.wiki.api.core.Page;
+import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.attachment.AttachmentManager;
+import org.apache.wiki.auth.AuthenticationManager;
+import org.apache.wiki.auth.AuthorizationManager;
+import org.apache.wiki.auth.WikiSecurityException;
+import org.apache.wiki.auth.permissions.PermissionFactory;
+import org.apache.wiki.pages.PageManager;
+import org.apache.wiki.pages.PageTimeComparator;
+import org.apache.wiki.plugin.WeblogEntryPlugin;
+import org.apache.wiki.plugin.WeblogPlugin;
+import org.apache.xmlrpc.XmlRpcException;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *  Provides handlers for all RPC routines of the MetaWeblog API.
+ *  <P>
+ *  JSPWiki does not support categories, and therefore we always return
+ *  an empty list for getCategories().  Note also that this API is not
+ *  suitable for general Wiki editing, since JSPWiki formats the entries
+ *  in a wiki-compatible manner.  And you cannot choose your page names
+ *  either.  Since 2.1.94 the entire MetaWeblog API is supported.
+ *
+ *  @since 2.1.7
+ */
+
+public class MetaWeblogHandler implements WikiRPCHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger( MetaWeblogHandler.class );
+
+    private Context m_context;
+
+    /**
+     *  {@inheritDoc}
+     */
+    @Override
+    public void initialize( final Context context )
+    {
+        m_context = context;
+    }
+
+    /**
+     *  Does a quick check against the current user
+     *  and does he have permissions to do the stuff
+     *  that he really wants to.
+     *  <p>
+     *  If there is no authentication enabled, returns normally.
+     *
+     *  @throws XmlRpcException with the correct error message, if auth fails.
+     */
+    private void checkPermissions( final Page page,
+                                   final String username,
+                                   final String password,
+                                   final String permission ) throws XmlRpcException {
+        try {
+            final AuthenticationManager amm = m_context.getEngine().getManager( AuthenticationManager.class );
+            final AuthorizationManager mgr = m_context.getEngine().getManager( AuthorizationManager.class );
+
+            if( amm.login( m_context.getWikiSession(), m_context.getHttpRequest(), username, password ) ) {
+                if( !mgr.checkPermission( m_context.getWikiSession(), PermissionFactory.getPagePermission( page, permission ) ) ) {
+                    throw new XmlRpcException( 1, "No permission" );
+                }
+            } else {
+                throw new XmlRpcException( 1, "Unknown login" );
+            }
+        } catch( final WikiSecurityException e ) {
+            throw new XmlRpcException( 1, e.getMessage(), e );
+        }
+    }
+
+    /**
+     *  JSPWiki does not support categories, therefore JSPWiki always returns an empty list for categories.
+     *
+     *  @param blogid The id of the blog.
+     *  @param username The username to use
+     *  @param password The password
+     *  @throws XmlRpcException If something goes wrong
+     *  @return An empty hashtable.
+     */
+    public Hashtable< Object, Object > getCategories( final String blogid, final String username, final String password )  throws XmlRpcException {
+        final Page page = m_context.getEngine().getManager( PageManager.class ).getPage( blogid );
+        checkPermissions( page, username, password, "view" );
+        return new Hashtable<>();
+    }
+
+    private String getURL( final String page ) {
+        return m_context.getEngine().getURL( ContextEnum.PAGE_VIEW.getRequestContext(), page,null );
+    }
+
+    /**
+     *  Takes a wiki page, and creates a metaWeblog struct out of it.
+     *
+     *  @param page The actual entry page
+     *  @return A metaWeblog entry struct.
+     */
+    private Hashtable< String,Object > makeEntry( final Page page ) {
+        final Page firstVersion = m_context.getEngine().getManager( PageManager.class ).getPage( page.getName(), 1 );
+        final Hashtable< String, Object > ht = new Hashtable<>();
+        ht.put( "dateCreated", firstVersion.getLastModified() );
+        ht.put( "link", getURL(page.getName() ) );
+        ht.put( "permaLink", getURL(page.getName() ) );
+        ht.put( "postid", page.getName() );
+        ht.put( "userid", page.getAuthor() );
+
+        final String pageText = m_context.getEngine().getManager( PageManager.class ).getText(page.getName());
+        final int firstLine = pageText.indexOf('\n');
+
+        String title = "";
+        if( firstLine > 0 ) {
+            title = pageText.substring( 0, firstLine );
+        }
+
+        if( title.trim().isEmpty() ) {
+            title = page.getName();
+        }
+
+        // Remove wiki formatting
+        while( title.startsWith("!") ) {
+            title = title.substring(1);
+        }
+
+        ht.put("title", title);
+        ht.put("description", pageText);
+
+        return ht;
+    }
+
+    /**
+     *  Returns a list of the recent posts to this weblog.
+     *
+     *  @param blogid The id of the blog.
+     *  @param username The username to use
+     *  @param password The password
+     *  @param numberOfPosts How many posts to find
+     *  @throws XmlRpcException If something goes wrong
+     *  @return As per MetaweblogAPI specification
+     */
+    // FIXME: The implementation is suboptimal, as it goes through all of the blog entries.
+    public Hashtable getRecentPosts( final String blogid, final String username, final String password, final int numberOfPosts ) throws XmlRpcException {
+        final Hashtable<String, Hashtable<String, Object>> result = new Hashtable<>();
+        LOG.info( "metaWeblog.getRecentPosts() called");
+        final Page page = m_context.getEngine().getManager( PageManager.class ).getPage( blogid );
+        checkPermissions( page, username, password, "view" );
+
+        final WeblogPlugin plugin = new WeblogPlugin();
+        final List< Page > changed = plugin.findBlogEntries( m_context.getEngine(), blogid, new Date( 0L ), new Date() );
+        changed.sort( new PageTimeComparator() );
+
+        int items = 0;
+        for( final Iterator< Page > i = changed.iterator(); i.hasNext() && items < numberOfPosts; items++ ) {
+            final Page p = i.next();
+            result.put( "entry", makeEntry( p ) );
+        }
+
+        return result;
+    }
+
+    /**
+     *  Adds a new post to the blog.
+     *
+     *  @param blogid The id of the blog.
+     *  @param username The username to use
+     *  @param password The password
+     *  @param content As per Metaweblogapi contract
+     *  @param publish This parameter is ignored for JSPWiki.
+     *  @return Returns an empty string
+     *  @throws XmlRpcException If something goes wrong
+     */
+    public String newPost( final String blogid,
+                           final String username,
+                           final String password,
+                           final Hashtable< String, Object > content,
+                           final boolean publish ) throws XmlRpcException {
+        LOG.info("metaWeblog.newPost() called");
+        final Engine engine = m_context.getEngine();
+        final Page page = engine.getManager( PageManager.class ).getPage( blogid );
+        checkPermissions( page, username, password, "createPages" );
+
+        try {
+            final WeblogEntryPlugin plugin = new WeblogEntryPlugin();
+            final String pageName = plugin.getNewEntryPage( engine, blogid );
+            final Page entryPage = Wiki.contents().page( engine, pageName );
+            entryPage.setAuthor( username );
+
+            final Context context = Wiki.context().create( engine, entryPage );
+            final StringBuilder text = new StringBuilder();
+            text.append( "!" ).append( content.get( "title" ) );
+            text.append( "\n\n" );
+            text.append( content.get("description") );
+
+            LOG.debug("Writing entry: "+text);
+
+            engine.getManager( PageManager.class ).saveText( context, text.toString() );
+        } catch( final Exception e ) {
+            LOG.error("Failed to create weblog entry",e);
+            throw new XmlRpcException( 0, "Failed to create weblog entry: "+e.getMessage() );
+        }
+
+        return ""; // FIXME:
+    }
+
+    /**
+     *  Creates an attachment and adds it to the blog.  The attachment
+     *  is created into the main blog page, not the actual post page,
+     *  because we do not know it at this point.
+     *
+     *  @param blogid The id of the blog.
+     *  @param username The username to use
+     *  @param password The password
+     *  @param content As per the MetaweblogAPI contract
+     *  @return As per the MetaweblogAPI contract
+     *  @throws XmlRpcException If something goes wrong
+     */
+    public Hashtable< String, Object > newMediaObject( final String blogid,
+                                                       final String username,
+                                                       final String password,
+                                                       final Hashtable< String, Object > content ) throws XmlRpcException {
+        final Engine engine = m_context.getEngine();
+        final String url;
+
+        LOG.info( "metaWeblog.newMediaObject() called" );
+
+        final Page page = engine.getManager( PageManager.class ).getPage( blogid );
+        checkPermissions( page, username, password, "upload" );
+
+        final String name = (String) content.get( "name" );
+        final byte[] data = (byte[]) content.get( "bits" );
+
+        final AttachmentManager attmgr = engine.getManager( AttachmentManager.class );
+
+        try {
+            final Attachment att = Wiki.contents().attachment( engine, blogid, name );
+            att.setAuthor( username );
+            attmgr.storeAttachment( att, new ByteArrayInputStream( data ) );
+
+            url = engine.getURL( ContextEnum.PAGE_ATTACH.getRequestContext(), att.getName(), null );
+        } catch( final Exception e ) {
+            LOG.error( "Failed to upload attachment", e );
+            throw new XmlRpcException( 0, "Failed to upload media object: "+e.getMessage() );
+        }
+
+        final Hashtable< String, Object > result = new Hashtable<>();
+        result.put("url", url);
+
+        return result;
+    }
+
+
+    /**
+     *  Allows the user to edit a post.  It does not allow general editability of wiki pages, because of the limitations of the metaWeblog API.
+     */
+    boolean editPost( final String postid,
+                      final String username,
+                      final String password,
+                      final Hashtable< String,Object > content,
+                      final boolean publish ) throws XmlRpcException {
+        final Engine engine = m_context.getEngine();
+        LOG.info("metaWeblog.editPost("+postid+") called");
+
+        // FIXME: Is postid correct?  Should we determine it from the page name?
+        final Page page = engine.getManager( PageManager.class ).getPage( postid );
+        checkPermissions( page, username, password, "edit" );
+
+        try {
+            final Page entryPage = page.clone();
+            entryPage.setAuthor( username );
+
+            final Context context = Wiki.context().create( engine, entryPage );
+
+            final StringBuilder text = new StringBuilder();
+            text.append( "!" ).append( content.get( "title" ) );
+            text.append( "\n\n" );
+            text.append( content.get("description") );
+
+            LOG.debug("Updating entry: "+text);
+
+            engine.getManager( PageManager.class ).saveText( context, text.toString() );
+        } catch( final Exception e ) {
+            LOG.error("Failed to create weblog entry",e);
+            throw new XmlRpcException( 0, "Failed to update weblog entry: "+e.getMessage() );
+        }
+
+        return true;
+    }
+
+    /**
+     *  Gets the text of any page.  The title of the page is parsed
+     *  (if any is provided).
+     */
+    Hashtable< String, Object > getPost( final String postid, final String username, final String password ) throws XmlRpcException {
+        final String wikiname = "FIXME";
+        final Page page = m_context.getEngine().getManager( PageManager.class ).getPage( wikiname );
+        checkPermissions( page, username, password, "view" );
+        return makeEntry( page );
+    }
+
+}

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCHandler.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCHandler.java
@@ -1,0 +1,272 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.apache.wiki.LinkCollector;
+import org.apache.wiki.api.core.Attachment;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.ContextEnum;
+import org.apache.wiki.api.core.Page;
+import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.auth.permissions.PagePermission;
+import org.apache.wiki.auth.permissions.PermissionFactory;
+import org.apache.wiki.pages.PageManager;
+import org.apache.wiki.render.RenderingManager;
+import org.apache.wiki.util.TextUtil;
+import org.apache.xmlrpc.XmlRpcException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
+/**
+ *  Provides handlers for all RPC routines.
+ *
+ *  @since 1.6.6
+ */
+// We could use Engine directly, but because of introspection it would show just too many methods to be safe.
+public class RPCHandler extends AbstractRPCHandler {
+
+    /**
+     *  Converts Java string into RPC string.
+     */
+    private String toRPCString( final String src )
+    {
+        return TextUtil.urlEncodeUTF8( src );
+    }
+
+    /**
+     *  Converts RPC string (UTF-8, url encoded) into Java string.
+     */
+    private String fromRPCString( final String src )
+    {
+        return TextUtil.urlDecodeUTF8( src );
+    }
+
+    /**
+     *  Transforms a Java string into UTF-8.
+     */
+    private byte[] toRPCBase64( final String src )
+    {
+        return src.getBytes( StandardCharsets.UTF_8 );
+    }
+
+    public String getApplicationName() {
+        checkPermission( PagePermission.VIEW );
+        return toRPCString(m_engine.getApplicationName());
+    }
+
+    public Vector< String > getAllPages() {
+        checkPermission( PagePermission.VIEW );
+        final Collection< Page > pages = m_engine.getManager( PageManager.class ).getRecentChanges();
+
+        return pages.stream().filter(p -> !(p instanceof Attachment)).map(p -> toRPCString(p.getName())).collect(Collectors.toCollection(Vector::new));
+    }
+
+    /**
+     *  Encodes a single wiki page info into a Hashtable.
+     */
+    @Override
+    protected Hashtable<String,Object> encodeWikiPage( final Page page ) {
+        final Hashtable<String, Object> ht = new Hashtable<>();
+        ht.put( "name", toRPCString(page.getName()) );
+
+        final Date d = page.getLastModified();
+
+        //
+        //  Here we reset the DST and TIMEZONE offsets of the
+        //  calendar.  Unfortunately, I haven't thought of a better
+        //  way to ensure that we're getting the proper date
+        //  from the XML-RPC thingy, except to manually adjust the date.
+        //
+
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( d );
+        cal.add( Calendar.MILLISECOND,
+                 - (cal.get( Calendar.ZONE_OFFSET ) +
+                    (cal.getTimeZone().inDaylightTime( d ) ? cal.get( Calendar.DST_OFFSET ) : 0 ) ) );
+
+        ht.put( "lastModified", cal.getTime() );
+        ht.put( "version", page.getVersion() );
+
+        if( page.getAuthor() != null ) {
+            ht.put( "author", toRPCString( page.getAuthor() ) );
+        }
+
+        return ht;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Vector< Hashtable< String, Object > > getRecentChanges( Date since ) {
+        checkPermission( PagePermission.VIEW );
+        final Set< Page > pages = m_engine.getManager( PageManager.class ).getRecentChanges();
+        final Vector< Hashtable< String, Object > > result = new Vector<>();
+
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( since );
+
+        //
+        //  Convert UTC to our time.
+        //
+        cal.add( Calendar.MILLISECOND,
+                 (cal.get( Calendar.ZONE_OFFSET ) +
+                  (cal.getTimeZone().inDaylightTime(since) ? cal.get( Calendar.DST_OFFSET ) : 0 ) ) );
+        since = cal.getTime();
+
+        for( final Page page : pages ) {
+            if( page.getLastModified().after( since ) && !(page instanceof Attachment) ) {
+                result.add( encodeWikiPage( page ) );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     *  Simple helper method, turns the incoming page name into
+     *  normal Java string, then checks page condition.
+     *
+     *  @param pagename Page Name as an RPC string (URL-encoded UTF-8)
+     *  @return Real page name, as Java string.
+     *  @throws XmlRpcException, if there is something wrong with the page.
+     */
+    private String parsePageCheckCondition( String pagename ) throws XmlRpcException {
+        pagename = fromRPCString( pagename );
+
+        if( !m_engine.getManager( PageManager.class ).wikiPageExists(pagename) ) {
+            throw new XmlRpcException( ERR_NOPAGE, "No such page '"+pagename+"' found, o master." );
+        }
+
+        final Page p = m_engine.getManager( PageManager.class ).getPage( pagename );
+
+        checkPermission( PermissionFactory.getPagePermission( p, PagePermission.VIEW_ACTION ) );
+
+        return pagename;
+    }
+
+    public Hashtable< String, Object > getPageInfo( String pagename ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+        return encodeWikiPage( m_engine.getManager( PageManager.class ).getPage(pagename) );
+    }
+
+    public Hashtable< String, Object > getPageInfoVersion( String pagename, final int version ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        return encodeWikiPage( m_engine.getManager( PageManager.class ).getPage( pagename, version ) );
+    }
+
+    public byte[] getPage( final String pagename ) throws XmlRpcException {
+        final String text = m_engine.getManager( PageManager.class ).getPureText( parsePageCheckCondition( pagename ), -1 );
+        return toRPCBase64( text );
+    }
+
+    public byte[] getPageVersion( String pagename, final int version ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        return toRPCBase64( m_engine.getManager( PageManager.class ).getPureText( pagename, version ) );
+    }
+
+    public byte[] getPageHTML( String pagename ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        return toRPCBase64( m_engine.getManager( RenderingManager.class ).getHTML( pagename ) );
+    }
+
+    public byte[] getPageHTMLVersion( String pagename, final int version ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        return toRPCBase64( m_engine.getManager( RenderingManager.class ).getHTML( pagename, version ) );
+    }
+
+    public Vector< Hashtable< String, String > > listLinks( String pagename ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        final Page page = m_engine.getManager( PageManager.class ).getPage( pagename );
+        final String pagedata = m_engine.getManager( PageManager.class ).getPureText( page );
+
+        final LinkCollector localCollector = new LinkCollector();
+        final LinkCollector extCollector   = new LinkCollector();
+        final LinkCollector attCollector   = new LinkCollector();
+
+        final Context context = Wiki.context().create( m_engine, page );
+        m_engine.getManager( RenderingManager.class ).textToHTML( context, pagedata, localCollector, extCollector, attCollector );
+
+        final Vector< Hashtable< String, String > > result = new Vector<>();
+
+        //
+        //  Add local links.
+        //
+        for( final String link : localCollector.getLinks() ) {
+            final Hashtable< String, String > ht = new Hashtable<>();
+            ht.put( "page", toRPCString( link ) );
+            ht.put( "type", LINK_LOCAL );
+
+            //
+            //  FIXME: This is a kludge.  The link format should really be queried
+            //  from the TranslatorReader itself.  Also, the link format should probably
+            //  have information on whether the page exists or not.
+            //
+
+            //
+            //  FIXME: The current link collector interface is not very good, since it causes this.
+            //
+
+            if( m_engine.getManager( PageManager.class ).wikiPageExists( link ) ) {
+                ht.put( "href", context.getURL( ContextEnum.PAGE_VIEW.getRequestContext(), link ) );
+            } else {
+                ht.put( "href", context.getURL( ContextEnum.PAGE_EDIT.getRequestContext(), link ) );
+            }
+
+            result.add( ht );
+        }
+
+        //
+        // Add links to inline attachments
+        //
+        for( final String link : attCollector.getLinks() ) {
+            final Hashtable<String, String> ht = new Hashtable<>();
+            ht.put( "page", toRPCString( link ) );
+            ht.put( "type", LINK_LOCAL );
+            ht.put( "href", context.getURL( ContextEnum.PAGE_ATTACH.getRequestContext(), link ) );
+            result.add( ht );
+        }
+
+        //
+        // External links don't need to be changed into XML-RPC strings, simply because URLs are by definition ASCII.
+        //
+        for( final String link : extCollector.getLinks() ) {
+            final Hashtable<String, String> ht = new Hashtable<>();
+            ht.put( "page", link );
+            ht.put( "type", LINK_EXTERNAL );
+            ht.put( "href", link );
+            result.add( ht );
+        }
+
+        return result;
+    }
+
+}

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCHandlerUTF8.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCHandlerUTF8.java
@@ -1,0 +1,223 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.apache.wiki.LinkCollector;
+import org.apache.wiki.api.core.Attachment;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.ContextEnum;
+import org.apache.wiki.api.core.Page;
+import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.auth.permissions.PagePermission;
+import org.apache.wiki.auth.permissions.PermissionFactory;
+import org.apache.wiki.pages.PageManager;
+import org.apache.wiki.render.RenderingManager;
+import org.apache.xmlrpc.XmlRpcException;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
+/**
+ *  Provides handlers for all RPC routines.  These routines are used by
+ *  the UTF-8 interface.
+ *
+ *  @since 1.6.13
+ */
+
+public class RPCHandlerUTF8 extends AbstractRPCHandler {
+
+    public String getApplicationName() {
+        checkPermission( PagePermission.VIEW );
+        return m_engine.getApplicationName();
+    }
+
+    public Vector< String > getAllPages() {
+        checkPermission( PagePermission.VIEW );
+
+        final Set< Page > pages = m_engine.getManager( PageManager.class ).getRecentChanges();
+
+        return pages.stream().filter(p -> !(p instanceof Attachment)).map(Page::getName).collect(Collectors.toCollection(Vector::new));
+    }
+
+    /**
+     *  Encodes a single wiki page info into a Hashtable.
+     */
+    @Override
+    protected Hashtable<String, Object> encodeWikiPage( final Page page ) {
+        final Hashtable<String, Object> ht = new Hashtable<>();
+        ht.put( "name", page.getName() );
+
+        final Date d = page.getLastModified();
+
+        //
+        //  Here we reset the DST and TIMEZONE offsets of the calendar.  Unfortunately, I haven't thought of a better
+        //  way to ensure that we're getting the proper date from the XML-RPC thingy, except to manually adjust the date.
+        //
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( d );
+        cal.add( Calendar.MILLISECOND,
+                 - (cal.get( Calendar.ZONE_OFFSET ) +
+                    (cal.getTimeZone().inDaylightTime( d ) ? cal.get( Calendar.DST_OFFSET ) : 0 )) );
+
+        ht.put( "lastModified", cal.getTime() );
+        ht.put( "version", page.getVersion() );
+
+        if( page.getAuthor() != null ) {
+            ht.put( "author", page.getAuthor() );
+        }
+
+        return ht;
+    }
+
+    @Override
+    public Vector< Hashtable< String, Object > > getRecentChanges( Date since ) {
+        checkPermission( PagePermission.VIEW );
+
+        final Set< Page > pages = m_engine.getManager( PageManager.class ).getRecentChanges();
+        final Vector< Hashtable< String, Object > > result = new Vector<>();
+
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( since );
+
+        //
+        //  Convert UTC to our time.
+        //
+        cal.add( Calendar.MILLISECOND,
+                 (cal.get( Calendar.ZONE_OFFSET ) +
+                  (cal.getTimeZone().inDaylightTime(since) ? cal.get( Calendar.DST_OFFSET ) : 0 ) ) );
+        since = cal.getTime();
+
+        for( final Page page : pages ) {
+            if( page.getLastModified().after( since ) && !( page instanceof Attachment ) ) {
+                result.add( encodeWikiPage( page ) );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     *  Simple helper method, turns the incoming page name into
+     *  normal Java string, then checks page condition.
+     *
+     *  @param pagename Page Name as an RPC string (URL-encoded UTF-8)
+     *  @return Real page name, as Java string.
+     *  @throws XmlRpcException, if there is something wrong with the page.
+     */
+    private String parsePageCheckCondition( final String pagename ) throws XmlRpcException {
+        if( !m_engine.getManager( PageManager.class ).wikiPageExists(pagename) ) {
+            throw new XmlRpcException( ERR_NOPAGE, "No such page '"+pagename+"' found, o master." );
+        }
+
+        final Page p = m_engine.getManager( PageManager.class ).getPage( pagename );
+
+        checkPermission( PermissionFactory.getPagePermission( p, PagePermission.VIEW_ACTION ) );
+        return pagename;
+    }
+
+    public Hashtable<String, Object> getPageInfo( final String pagename ) throws XmlRpcException {
+        return encodeWikiPage( m_engine.getManager( PageManager.class ).getPage( parsePageCheckCondition( pagename ) ) );
+    }
+
+    public Hashtable<String, Object> getPageInfoVersion( String pagename, final int version ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        return encodeWikiPage( m_engine.getManager( PageManager.class ).getPage( pagename, version ) );
+    }
+
+    public String getPage( final String pagename ) throws XmlRpcException {
+        return m_engine.getManager( PageManager.class ).getPureText( parsePageCheckCondition( pagename ), -1 );
+    }
+
+    public String getPageVersion( final String pagename, final int version ) throws XmlRpcException {
+        return m_engine.getManager( PageManager.class ).getPureText( parsePageCheckCondition( pagename ), version );
+    }
+
+    public String getPageHTML( final String pagename ) throws XmlRpcException  {
+        return m_engine.getManager( RenderingManager.class ).getHTML( parsePageCheckCondition( pagename ) );
+    }
+
+    public String getPageHTMLVersion( final String pagename, final int version ) throws XmlRpcException {
+        return m_engine.getManager( RenderingManager.class ).getHTML( parsePageCheckCondition( pagename ), version );
+    }
+
+    public Vector< Hashtable< String, String > > listLinks( String pagename ) throws XmlRpcException {
+        pagename = parsePageCheckCondition( pagename );
+
+        final Page page = m_engine.getManager( PageManager.class ).getPage( pagename );
+        final String pagedata = m_engine.getManager( PageManager.class ).getPureText( page );
+
+        final LinkCollector localCollector = new LinkCollector();
+        final LinkCollector extCollector   = new LinkCollector();
+        final LinkCollector attCollector   = new LinkCollector();
+
+        final Context context = Wiki.context().create( m_engine, page );
+        m_engine.getManager( RenderingManager.class ).textToHTML( context, pagedata, localCollector, extCollector, attCollector );
+
+        final Vector< Hashtable< String, String > > result = new Vector<>();
+
+        // FIXME: Contains far too much common with RPCHandler.  Refactor!
+
+        //
+        //  Add local links.
+        //
+        for( final String link : localCollector.getLinks() ) {
+            final Hashtable<String, String> ht = new Hashtable<>();
+            ht.put( "page", link );
+            ht.put( "type", LINK_LOCAL );
+
+            if( m_engine.getManager( PageManager.class ).wikiPageExists( link ) ) {
+                ht.put( "href", context.getViewURL( link ) );
+            } else {
+                ht.put( "href", context.getURL( ContextEnum.PAGE_EDIT.getRequestContext(), link ) );
+            }
+
+            result.add( ht );
+        }
+
+        //
+        // Add links to inline attachments
+        //
+        for( final String link : attCollector.getLinks() ) {
+            final Hashtable<String, String> ht = new Hashtable<>();
+            ht.put( "page", link );
+            ht.put( "type", LINK_LOCAL );
+            ht.put( "href", context.getURL( ContextEnum.PAGE_ATTACH.getRequestContext(), link ) );
+            result.add( ht );
+        }
+
+        //
+        // External links don't need to be changed into XML-RPC strings, simply because URLs are by definition ASCII.
+        //
+        for( final String link : extCollector.getLinks() )  {
+            final Hashtable<String, String> ht = new Hashtable<>();
+            ht.put( "page", link );
+            ht.put( "type", LINK_EXTERNAL );
+            ht.put( "href", link );
+            result.add( ht );
+        }
+
+        return result;
+    }
+
+}

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCServlet.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/RPCServlet.java
@@ -1,0 +1,208 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.ContextEnum;
+import org.apache.wiki.api.core.Engine;
+import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.util.ClassUtil;
+import org.apache.xmlrpc.ContextXmlRpcHandler;
+import org.apache.xmlrpc.Invoker;
+import org.apache.xmlrpc.XmlRpcContext;
+import org.apache.xmlrpc.XmlRpcHandlerMapping;
+import org.apache.xmlrpc.XmlRpcServer;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.Vector;
+
+/**
+ *  Handles all incoming servlet requests for XML-RPC calls.
+ *  <P>
+ *  Uses two initialization parameters:
+ *  <UL>
+ *  <LI><B>handler</B> : the class which is used to handle the RPC calls.
+ *  <LI><B>prefix</B> : The command prefix for that particular handler.
+ *  </UL>
+ *
+ *  @since 1.6.6
+ */
+public class RPCServlet extends HttpServlet {
+    private static final long serialVersionUID = 3976735878410416180L;
+
+    /** This is what is appended to each command, if the handler has not been specified. */
+    // FIXME: Should this be $default?
+    public static final String XMLRPC_PREFIX = "wiki";
+
+    private Engine m_engine;
+    private final XmlRpcServer m_xmlrpcServer = new XmlRpcServer();
+
+    private static final Logger LOG = LoggerFactory.getLogger( RPCServlet.class );
+
+    public void initHandler( final String prefix, final String handlerName ) throws ClassNotFoundException {
+        /*
+        Class handlerClass = Class.forName( handlerName );
+        WikiRPCHandler rpchandler = (WikiRPCHandler) handlerClass.newInstance();
+        rpchandler.initialize( m_engine );
+        m_xmlrpcServer.addHandler( prefix, rpchandler );
+        */
+        final Class< WikiRPCHandler > handlerClass = ClassUtil.findClass( "", handlerName );
+        m_xmlrpcServer.addHandler( prefix, new LocalHandler( handlerClass ) );
+    }
+
+    /**
+     *  Initializes the servlet.
+     */
+    @Override
+    public void init( final ServletConfig config ) throws ServletException {
+        m_engine = Wiki.engine().find( config );
+
+        String handlerName = config.getInitParameter( "handler" );
+        String prefix      = config.getInitParameter( "prefix" );
+
+        if( handlerName == null ) {
+            handlerName = "org.apache.wiki.xmlrpc.RPCHandler";
+        }
+        if( prefix == null ) {
+            prefix = XMLRPC_PREFIX;
+        }
+
+        try {
+            initHandler( prefix, handlerName );
+
+            // FIXME: The metaweblog API should be possible to turn off.
+            initHandler( "metaWeblog", "org.apache.wiki.xmlrpc.MetaWeblogHandler" );
+        } catch( final Exception e ) {
+            LOG.error("Unable to start RPC interface: ", e);
+            throw new ServletException( "No RPC interface", e );
+        }
+    }
+
+    /**
+     *  Handle HTTP POST.  This is an XML-RPC call, and we'll just forward the query to an XmlRpcServer.
+     */
+    @Override
+    public void doPost( final HttpServletRequest request, final HttpServletResponse response ) throws ServletException {
+        LOG.debug("Received POST to RPCServlet");
+
+        try {
+            final Context ctx = Wiki.context().create( m_engine, request, ContextEnum.PAGE_NONE.getRequestContext() );
+            final XmlRpcContext xmlrpcContext = new WikiXmlRpcContext( m_xmlrpcServer.getHandlerMapping(), ctx );
+            final byte[] result = m_xmlrpcServer.execute( request.getInputStream(), xmlrpcContext );
+
+            //
+            //  I think it's safe to write the output as UTF-8: The XML-RPC standard never creates other than USASCII
+            //  (which is UTF-8 compatible), and our special UTF-8 hack just creates UTF-8.  So in all cases our butt
+            //  should be covered.
+            //
+            response.setContentType( "text/xml; charset=utf-8" );
+            response.setContentLength( result.length );
+
+            final OutputStream out = response.getOutputStream();
+            out.write( result );
+            out.flush();
+
+            // LOG.debug("Result = "+new String(result) );
+        } catch( final IOException e ) {
+            throw new ServletException("Failed to build RPC result", e);
+        }
+    }
+
+    /**
+     *  Handles HTTP GET.  However, we do not respond to GET requests, other than to show an explanatory text.
+     */
+    @Override
+    public void doGet( final HttpServletRequest request, final HttpServletResponse response ) throws ServletException {
+        LOG.debug("Received HTTP GET to RPCServlet");
+
+        try {
+            final String msg = "We do not support HTTP GET here.  Sorry.";
+            response.setContentType( "text/plain" );
+            response.setContentLength( msg.length() );
+
+            final PrintWriter writer = new PrintWriter( new OutputStreamWriter( response.getOutputStream() ) );
+
+            writer.println( msg );
+            writer.flush();
+        } catch( final IOException e ) {
+            throw new ServletException("Failed to build RPC result", e);
+        }
+    }
+
+    private static class LocalHandler implements ContextXmlRpcHandler {
+        private final Class< WikiRPCHandler > m_clazz;
+
+        public LocalHandler( final Class< WikiRPCHandler > clazz )
+        {
+            m_clazz = clazz;
+        }
+
+        @Override
+        public Object execute( final String method, final Vector params, final XmlRpcContext context ) throws Exception {
+            final WikiRPCHandler rpchandler = ClassUtil.buildInstance( m_clazz );
+            rpchandler.initialize( ((WikiXmlRpcContext)context).getWikiContext() );
+
+            final Invoker invoker = new Invoker( rpchandler );
+            return invoker.execute( method, params );
+        }
+    }
+
+    private static class WikiXmlRpcContext implements XmlRpcContext {
+
+        private final XmlRpcHandlerMapping m_mapping;
+        private final Context m_context;
+
+        public WikiXmlRpcContext( final XmlRpcHandlerMapping map, final Context ctx ) {
+            m_mapping = map;
+            m_context = ctx;
+        }
+
+        @Override
+        public XmlRpcHandlerMapping getHandlerMapping()
+        {
+            return m_mapping;
+        }
+
+        @Override
+        public String getPassword() {
+            return null;
+        }
+
+        @Override
+        public String getUserName() {
+            return null;
+        }
+
+        public Context getWikiContext()
+        {
+            return m_context;
+        }
+    }
+
+}

--- a/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/WikiRPCHandler.java
+++ b/jspwiki-xmlrpc/src/main/java/org/apache/wiki/xmlrpc/WikiRPCHandler.java
@@ -1,0 +1,34 @@
+/* 
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.  
+ */
+package org.apache.wiki.xmlrpc;
+
+import org.apache.wiki.api.core.Context;
+
+
+/**
+ *  Any wiki RPC handler should implement this so that they can be properly initialized and recognized by JSPWiki.
+ *
+ *  @since 2.1.7
+ */
+// FIXME3.0: This class is fast becoming obsolete.  It should be moved to the "rpc" package in 3.0
+public interface WikiRPCHandler {
+
+    void initialize( Context context );
+
+}

--- a/jspwiki-xmlrpc/src/main/resources/META-INF/web-fragment.xml
+++ b/jspwiki-xmlrpc/src/main/resources/META-INF/web-fragment.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<web-fragment xmlns="http://java.sun.com/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd"
+              version="3.0">
+              
+              
+   <!--
+       Now, let's define the XML-RPC interfaces.  You probably don't have to
+       touch these.
+
+       First, we'll define the standard XML-RPC interface.
+     -->
+   <servlet>
+       <servlet-name>XMLRPC</servlet-name>
+       <servlet-class>org.apache.wiki.xmlrpc.RPCServlet</servlet-class>
+       <init-param>
+           <param-name>handler</param-name>
+           <param-value>org.apache.wiki.xmlrpc.RPCHandler</param-value>
+       </init-param>
+
+       <init-param>
+           <param-name>prefix</param-name>
+           <param-value>wiki</param-value>
+       </init-param>
+   </servlet>
+
+   <!--
+       OK, this then defines that our UTF-8 -capable server.
+     -->
+
+   <servlet>
+       <servlet-name>XMLRPC-UTF8</servlet-name>
+       <servlet-class>org.apache.wiki.xmlrpc.RPCServlet</servlet-class>
+       <init-param>
+           <param-name>handler</param-name>
+           <param-value>org.apache.wiki.xmlrpc.RPCHandlerUTF8</param-value>
+       </init-param>
+
+       <init-param>
+           <param-name>prefix</param-name>
+           <param-value>wiki</param-value>
+       </init-param>
+   </servlet>
+
+   <!--
+        And finally, let us tell the servlet container which
+        URLs should correspond to which XML RPC servlet.
+        By default, this is disabled.  If you want to enable it,
+        just uncomment the whole section.
+    -->
+
+    <!--  REMOVE ME TO ENABLE XML-RPC
+    <servlet-mapping>
+        <servlet-name>XMLRPC</servlet-name>
+        <url-pattern>/RPC2/</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>XMLRPC-UTF8</servlet-name>
+        <url-pattern>/RPCU/</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ATOM</servlet-name>
+        <url-pattern>/atom/*</url-pattern>
+    </servlet-mapping>
+    AND REMOVE ME TOO -->
+              
+
+</web-fragment>

--- a/jspwiki-xmlrpc/src/test/java/org/apache/wiki/xmlrpc/RPCHandlerTest.java
+++ b/jspwiki-xmlrpc/src/test/java/org/apache/wiki/xmlrpc/RPCHandlerTest.java
@@ -1,0 +1,222 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+
+package org.apache.wiki.xmlrpc;
+
+import org.apache.wiki.TestEngine;
+import org.apache.wiki.api.core.Attachment;
+import org.apache.wiki.api.core.Context;
+import org.apache.wiki.api.core.Page;
+import org.apache.wiki.api.spi.Wiki;
+import org.apache.wiki.attachment.AttachmentManager;
+import org.apache.wiki.pages.PageManager;
+import org.apache.xmlrpc.XmlRpcException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Vector;
+
+public class RPCHandlerTest {
+
+    TestEngine m_engine = TestEngine.build();
+    RPCHandler m_handler;
+
+    static final String NAME1 = "Test";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        m_handler = new RPCHandler();
+        final Context ctx = Wiki.context().create( m_engine, Wiki.contents().page( m_engine, "Dummy" ) );
+        m_handler.initialize( ctx );
+    }
+
+    @AfterEach
+    public void tearDown() {
+        m_engine.stop();
+    }
+
+    @Test
+    public void testNonexistantPage() {
+        try {
+            m_handler.getPage( "NoSuchPage" );
+            Assertions.fail( "No exception for missing page." );
+        } catch ( final XmlRpcException e ) {
+            Assertions.assertEquals( RPCHandler.ERR_NOPAGE, e.code, "Wrong error code." );
+        }
+    }
+
+    @Test
+    public void testRecentChanges()
+            throws Exception {
+        Date time = getCalendarTime( Calendar.getInstance().getTime() );
+        final Vector< Hashtable< String, Object > > previousChanges = m_handler.getRecentChanges( time );
+
+        m_engine.saveText( NAME1, "Foo" );
+        final Page directInfo = m_engine.getManager( PageManager.class ).getPage( NAME1 );
+        time = getCalendarTime( directInfo.getLastModified() );
+        final Vector< Hashtable< String, Object > > recentChanges = m_handler.getRecentChanges( time );
+
+        Assertions.assertEquals( 1, recentChanges.size() - previousChanges.size(), "wrong number of changes" );
+    }
+
+    @Test
+    public void testRecentChangesWithAttachments()
+            throws Exception {
+        Date time = getCalendarTime( Calendar.getInstance().getTime() );
+        final Vector< Hashtable< String, Object > > previousChanges = m_handler.getRecentChanges( time );
+
+        m_engine.saveText( NAME1, "Foo" );
+        final Attachment att = Wiki.contents().attachment( m_engine, NAME1, "TestAtt.txt" );
+        att.setAuthor( "FirstPost" );
+        m_engine.getManager( AttachmentManager.class ).storeAttachment( att, m_engine.makeAttachmentFile() );
+        final Page directInfo = m_engine.getManager( PageManager.class ).getPage( NAME1 );
+        time = getCalendarTime( directInfo.getLastModified() );
+        final Vector< Hashtable< String, Object > > recentChanges = m_handler.getRecentChanges( time );
+
+        Assertions.assertEquals( 1, recentChanges.size() - previousChanges.size(), "wrong number of changes" );
+    }
+
+    @Test
+    public void testPageInfo()
+            throws Exception {
+        m_engine.saveText( NAME1, "Foobar.[{ALLOW view Anonymous}]" );
+        final Page directInfo = m_engine.getManager( PageManager.class ).getPage( NAME1 );
+
+        final Hashtable< String, Object > ht = m_handler.getPageInfo( NAME1 );
+        Assertions.assertEquals( ht.get( "name" ), NAME1, "name" );
+
+        final Date d = ( Date ) ht.get( "lastModified" );
+
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( d );
+
+        // System.out.println("Real: "+directInfo.getLastModified() );
+        // System.out.println("RPC:  "+d );
+
+        // Offset the ZONE offset and DST offset away.  DST only
+        // if we're actually in DST.
+        cal.add( Calendar.MILLISECOND,
+                ( cal.get( Calendar.ZONE_OFFSET ) +
+                        ( cal.getTimeZone().inDaylightTime( d ) ? cal.get( Calendar.DST_OFFSET ) : 0 ) ) );
+        // System.out.println("RPC2: "+cal.getTime() );
+
+        Assertions.assertEquals( cal.getTime().getTime(), directInfo.getLastModified().getTime(), "date" );
+    }
+
+    /**
+     * Tests if listLinks() works with a single, non-existant local page.
+     */
+    @Test
+    public void testListLinks()
+            throws Exception {
+        final String text = "[Foobar]";
+        final String pageName = NAME1;
+
+        m_engine.saveText( pageName, text );
+
+        final Vector< Hashtable< String, String > > links = m_handler.listLinks( pageName );
+
+        Assertions.assertEquals( 1, links.size(), "link count" );
+
+        final Hashtable< String, String > linkinfo = links.elementAt( 0 );
+
+        Assertions.assertEquals( "Foobar", linkinfo.get( "page" ), "name" );
+        Assertions.assertEquals( "local", linkinfo.get( "type" ), "type" );
+        Assertions.assertEquals( "/test/Edit.jsp?page=Foobar", linkinfo.get( "href" ), "href" );
+    }
+
+
+    @Test
+    public void testListLinksWithAttachments()
+            throws Exception {
+        final String text = "[Foobar] [Test/TestAtt.txt]";
+        final String pageName = NAME1;
+
+        m_engine.saveText( pageName, text );
+
+        final Attachment att = Wiki.contents().attachment( m_engine, NAME1, "TestAtt.txt" );
+        att.setAuthor( "FirstPost" );
+        m_engine.getManager( AttachmentManager.class ).storeAttachment( att, m_engine.makeAttachmentFile() );
+
+        // Test.
+
+        final Vector< Hashtable< String, String > > links = m_handler.listLinks( pageName );
+
+        Assertions.assertEquals( 2, links.size(), "link count" );
+
+        Hashtable< String, String > linkinfo = links.elementAt( 0 );
+
+        Assertions.assertEquals( "Foobar", linkinfo.get( "page" ), "edit name" );
+        Assertions.assertEquals( "local", linkinfo.get( "type" ), "edit type" );
+        Assertions.assertEquals( "/test/Edit.jsp?page=Foobar", linkinfo.get( "href" ), "edit href" );
+
+        linkinfo = links.elementAt( 1 );
+
+        Assertions.assertEquals( NAME1 + "/TestAtt.txt", linkinfo.get( "page" ), "att name" );
+        Assertions.assertEquals( "local", linkinfo.get( "type" ), "att type" );
+        Assertions.assertEquals( "/test/attach/" + NAME1 + "/TestAtt.txt", linkinfo.get( "href" ), "att href" );
+    }
+
+    private Date getCalendarTime( final Date modifiedDate ) {
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime( modifiedDate );
+        cal.add( Calendar.HOUR, -1 );
+
+        // Go to UTC
+        // Offset the ZONE offset and DST offset away.  DST only
+        // if we're actually in DST.
+        cal.add( Calendar.MILLISECOND,
+                -( cal.get( Calendar.ZONE_OFFSET ) +
+                        ( cal.getTimeZone().inDaylightTime( modifiedDate ) ? cal.get( Calendar.DST_OFFSET ) : 0 ) ) );
+
+        return cal.getTime();
+    }
+
+    /*
+     * TODO: ENABLE
+    @Test
+    public void testPermissions()
+        throws Exception
+    {
+        String text ="Blaa. [{DENY view Guest}] [{ALLOW view NamedGuest}]";
+
+        m_engine.saveText( NAME1, text );
+
+        try
+        {
+            Vector links = m_handler.listLinks( NAME1 );
+            Assertions.fail("Didn't get an exception in listLinks()");
+        }
+        catch( XmlRpcException e ) {}
+
+        try
+        {
+            Hashtable ht = m_handler.getPageInfo( NAME1 );
+            Assertions.fail("Didn't get an exception in getPageInfo()");
+        }
+        catch( XmlRpcException e ) {}
+    }
+*/
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <slf4j.version>2.0.17</slf4j.version>
     <tika.version>3.2.3</tika.version>
     <tomcat.version>10.1.49</tomcat.version>
+    <xmlrpc.version>2.0.1</xmlrpc.version>
     <xstream.version>1.4.21</xstream.version>
 
     <plugin.antrun.version>3.2.0</plugin.antrun.version>
@@ -441,6 +442,12 @@
         <groupId>oro</groupId>
         <artifactId>oro</artifactId>
         <version>${oro.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>xmlrpc</groupId>
+        <artifactId>xmlrpc</artifactId>
+        <version>${xmlrpc.version}</version>
       </dependency>
 
       <!-- test dependencies -->


### PR DESCRIPTION
Align knowwe-3.0's XML-RPC handling with upstream JSPWiki 3.0 exactly, reversing the earlier full removal.

Upstream 3.0 does **not** build or ship XML-RPC: the `org.apache.wiki.xmlrpc` sources sit in the tree as **orphaned dead source** (no pom, not a reactor module), only `PingWeblogsComFilter` (jspwiki-main) is compiled against the `xmlrpc` client library, and the XML-RPC servlet mapping is commented out. The fork never customized any of this, so matching upstream keeps divergence minimal.

Changes (exact inverse of the earlier removal; adapted state = jakarta + slf4j + coordinates, already present pre-removal):
- Restore `jspwiki-xmlrpc/` sources (NOT added to the reactor — dead source, as upstream).
- Restore `PingWeblogsComFilter` in jspwiki-main + the `xmlrpc:xmlrpc` dependency (root depMgmt + jspwiki-main).
- Restore the `/RPC2/`,`/RPCU/` url-patterns on the WikiServletFilter mapping; the XMLRPC `<servlet-mapping>` stays commented.

No functional endpoint is added (upstream has none either); this only removes a KnowWE-specific divergence and eliminates the dangling-class-reference inconsistency in the it-test descriptors.

Local build (Zulu 21) green; jspwiki-xmlrpc correctly not built; only the known `GroupPermissionTest.testImpliesMember` SecurityManager flake fails (passes on ubuntu CI).