### PR TITLE
Catch up with fork master, and restore the dropped lucene-10 / JDK-21 baseline

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/permissions/GroupPermission.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/permissions/GroupPermission.java
@@ -19,15 +19,11 @@
 package org.apache.wiki.auth.permissions;
 
 import java.io.Serializable;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.DomainCombiner;
 import java.security.Permission;
 import java.util.Arrays;
 import java.util.Set;
 
 import javax.security.auth.Subject;
-import javax.security.auth.SubjectDomainCombiner;
 
 import org.apache.wiki.auth.GroupPrincipal;
 
@@ -388,18 +384,18 @@ public final class GroupPermission extends Permission implements Serializable
      * "TestGroup" only if the Subject is a member of TestGroup.
      * </p>
      * <p>
-     * We make this determination by obtaining the current {@link Thread}&#8217;s
-     * {@link java.security.AccessControlContext} and requesting the
-     * {@link javax.security.auth.SubjectDomainCombiner}. If the combiner is
-     * not <code>null</code>, then we know that the access check was
+     * We make this determination by obtaining the current thread&#8217;s Subject
+     * via {@link javax.security.auth.Subject#current()}. If it is not
+     * <code>null</code>, then we know that the access check was
      * requested using a {@link javax.security.auth.Subject}; that is, that an
-     * upstream caller caused a Subject to be associated with the Thread&#8217;s
-     * ProtectionDomain by executing a
+     * upstream caller caused a Subject to be bound to the current thread by
+     * executing a
      * {@link javax.security.auth.Subject#doAs(Subject, java.security.PrivilegedAction)}
+     * or {@link javax.security.auth.Subject#callAs(Subject, java.util.concurrent.Callable)}
      * operation.
      * </p>
      * <p>
-     * If a SubjectDomainCombiner exists, determining group membership is
+     * If such a Subject exists, determining group membership is
      * simple: just iterate through the Subject&#8217;s Principal set and look for all
      * Principals of type {@link org.apache.wiki.auth.GroupPrincipal}. If the
      * name of any Principal matches the value of the implied Permission&#8217;s
@@ -477,15 +473,15 @@ public final class GroupPermission extends Permission implements Serializable
             return false;
         }
 
-        // For the current thread, retrieve the SubjectDomainCombiner
-        // (if one was used to create current AccessControlContext )
-        final AccessControlContext acc = AccessController.getContext();
-        final DomainCombiner dc = acc.getDomainCombiner();
-        if ( dc != null && dc instanceof SubjectDomainCombiner )
+        // Retrieve the Subject bound to the current thread by Subject.doAs/callAs.
+        // Subject.current() covers all JVMs >= 18: before JDK 23 it resolves the Subject
+        // from the AccessControlContext's SubjectDomainCombiner internally, since JDK 23
+        // (Security Manager removal, JEP 486) from the scoped value bound by doAs/callAs.
+        final Subject subject = Subject.current();
+        if ( subject != null )
         {
             // <member> implies permission if subject possesses
             // GroupPrincipal with same name as target
-            final Subject subject = ( (SubjectDomainCombiner) dc ).getSubject();
             final Set<GroupPrincipal> principals = subject.getPrincipals( GroupPrincipal.class );
             return principals.stream().anyMatch(principal -> principal.getName().equals(gp.m_group));
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
@@ -115,7 +115,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
 	 * {@link #ensureCreationDateProperties(Page, Properties)} for how it is applied.
 	 */
 	public static final String RESTORE_CREATION_DATES_FILE = "restore-creation-dates.properties";
-	private CachedProperties m_cachedProperties;
+	private volatile CachedProperties m_cachedProperties;
 
 	/**
 	 * {@inheritDoc}
@@ -1018,9 +1018,9 @@ public class VersioningFileProvider extends AbstractFileProvider {
 	 * gain over simply keeping the last one requested.
 	 */
 	private static class CachedProperties {
-		String m_page;
-		Properties m_props;
-		long m_lastModified;
+		final String m_page;
+		final Properties m_props;
+		final long m_lastModified;
 
 		/**
 		 * Because a Constructor is inherently synchronised, there is no need to synchronise the arguments.

--- a/jspwiki-multiwiki/src/main/java/org/apache/wiki/SubWikiInit.java
+++ b/jspwiki-multiwiki/src/main/java/org/apache/wiki/SubWikiInit.java
@@ -27,7 +27,8 @@ public class SubWikiInit {
 		assert folders != null;
 		Collection<File> filteredFolders = Arrays.stream(folders).filter(file ->
 				file.isDirectory()
-						&& !file.getAbsolutePath().equals(".git")
+						// skips .git and any other hidden directory, these are never sub-wikis
+						&& !file.getName().startsWith(".")
 						&& !file.getAbsolutePath().equals(m_pageDirectory)
 						&& !file.getName().equals("OLD")
 						&& !file.getParentFile().getName().equals("OLD")

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputTimestamp>2026-03-21T15:16:08Z</project.build.outputTimestamp> <!-- will be changed by release plugin during releases -->
-    <jdk.version>17</jdk.version>
+    <jdk.version>21</jdk.version>
     <jdk.javadoc.doclet.version>2.2.3</jdk.javadoc.doclet.version>
     <maven.version>3.5</maven.version>
 
@@ -79,7 +79,7 @@
     <jrcs-diff.version>0.4.2</jrcs-diff.version>
     <junit.version>6.0.1</junit.version>
     <logback.version>1.5.19</logback.version>
-    <lucene.version>9.12.2</lucene.version>
+    <lucene.version>10.4.0</lucene.version>
     <mockito.version>5.20.0</mockito.version>
     <nekohtml.version>2.1.3</nekohtml.version>
     <oro.version>2.0.8</oro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <junit.version>6.0.1</junit.version>
     <logback.version>1.5.19</logback.version>
     <lucene.version>10.4.0</lucene.version>
-    <mockito.version>5.20.0</mockito.version>
+    <mockito.version>5.23.0</mockito.version> <!-- 5.23.0 -> byte-buddy 1.17.x, Java-25-fähig -->
     <nekohtml.version>2.1.3</nekohtml.version>
     <oro.version>2.0.8</oro.version>
     <rome.version>2.1.0</rome.version>


### PR DESCRIPTION
Brings `knowwe-3.0` up to date with the fork's `master`, and restores a fork divergence the ledger dropped.

### The five commits past `4ba8d671`

| fork commit | disposition |
| --- | --- |
| `a0b5cc8a` fix tests for jdk25 | **PICK** — `GroupPermission` moves off `SubjectDomainCombiner` to `Subject.current()`; mockito 5.20.0 → 5.23.0 |
| `4dedb2fa` bump to 2.12.7 | INFRA — version bump only; this line is `3.0.0-SNAPSHOT` |
| `c3ac9370` Bump jspwiki | INFRA — same, plus a `LICENSE` line the bump script mangled (rewrote the bundled `jackson-*-2.12.7.1` entries to `2.12.8-SNAPSHOT.1`), deliberately not carried over |
| `c2c73dca` thread safety | **PICK** — `VersioningFileProvider` cached properties `volatile`/`final` |
| `f6314273` sub wiki init skip any hidden directory | **PICK** — `SubWikiInit` filters all dotted directories |

### Plus `ad3f5adb6`, re-dispositioned `SKIP:superseded` → `PICK`

`Subject.current()` needs a Java 18+ baseline, and the apache parent derives `maven.compiler.release` from `jdk.version` — which was still upstream's 17 here while the fork has been on 21. Tracing that back: the fork's 17 → 21 bump rode along inside `ad3f5adb6` *"lucene 10 compatibility"*, which was skipped on lucene grounds. The skip was half right — upstream RC1 already uses `reader.storedFields()`, so the code half really was superseded — but **both property bumps were losses**: `lucene` 9.12.2 → 10.4.0 as well as `jdk` 17 → 21. The coupling isn't incidental: Lucene 10 requires Java 21.

So the commit is cherry-picked `-x` with its original author rather than reconstructed, and the JDK baseline arrives with it.

### Verification

- All three ported files from `master` are byte-identical to the fork tip afterwards (only the fork's accidental `100644→100755` mode flips dropped).
- `mvn -B -T1C package` green locally on lucene 10, including all 925 `jspwiki-main` tests and both search-provider modules.
- An oversight sweep for more losses of this kind found none: every `<x.version>` property compared (the fork is ahead in exactly `jdk`, `mockito`, `lucene` — all now covered), all 153 `SKIP` rows screened for dropped non-pom content, and a file-level sweep for fork files absent here (only decision-governed drops). One trivial residual: the fork's extra `.gitignore` entries.

### CI

Red here for a pre-existing reason, unrelated to this PR — see the comment below. #52 is that fix as a single commit stacked on this branch, and it is **green**.
