### PR TITLE
CI probe: jdk.version 21 only (do not merge)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputTimestamp>2026-03-21T15:16:08Z</project.build.outputTimestamp> <!-- will be changed by release plugin during releases -->
-    <jdk.version>17</jdk.version>
+    <jdk.version>21</jdk.version>
     <jdk.javadoc.doclet.version>2.2.3</jdk.javadoc.doclet.version>
     <maven.version>3.5</maven.version>
 


### PR DESCRIPTION
Temporary CI probe isolating the jdk.version 17 -> 21 bump. Will be closed.