### PR TITLE
Isolate each engine's caches from other engines in the same JVM

### DIFF
--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
@@ -74,11 +74,12 @@ public class EhcacheCachingManager implements CachingManager, Initializable {
 			final URL location = this.getClass().getResource(confLocation);
 			LOG.info("Reading ehcache configuration file from classpath on /{}", location);
 			if (engine != null) {
-				// Distinct engines get distinct CacheManagers, named by application name, so their
-				// caches do not collide (required for the multi-wiki / multi-instance case).
+				// One CacheManager per engine instance: ehcache hands back an existing CacheManager when
+				// the configured name is already in use, so the name must identify the engine, not just
+				// the application.
 				final Configuration configuration = ConfigurationFactory.parseConfiguration(location);
 				if (configuration.getName() == null) {
-					configuration.name(engine.getApplicationName());
+					configuration.name(engine.getApplicationName() + "-" + System.identityHashCode(engine));
 				}
 				cacheManager = CacheManager.newInstance(configuration);
 			}

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/permissions/GroupPermission.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/permissions/GroupPermission.java
@@ -19,15 +19,11 @@
 package org.apache.wiki.auth.permissions;
 
 import java.io.Serializable;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.DomainCombiner;
 import java.security.Permission;
 import java.util.Arrays;
 import java.util.Set;
 
 import javax.security.auth.Subject;
-import javax.security.auth.SubjectDomainCombiner;
 
 import org.apache.wiki.auth.GroupPrincipal;
 
@@ -388,18 +384,18 @@ public final class GroupPermission extends Permission implements Serializable
      * "TestGroup" only if the Subject is a member of TestGroup.
      * </p>
      * <p>
-     * We make this determination by obtaining the current {@link Thread}&#8217;s
-     * {@link java.security.AccessControlContext} and requesting the
-     * {@link javax.security.auth.SubjectDomainCombiner}. If the combiner is
-     * not <code>null</code>, then we know that the access check was
+     * We make this determination by obtaining the current thread&#8217;s Subject
+     * via {@link javax.security.auth.Subject#current()}. If it is not
+     * <code>null</code>, then we know that the access check was
      * requested using a {@link javax.security.auth.Subject}; that is, that an
-     * upstream caller caused a Subject to be associated with the Thread&#8217;s
-     * ProtectionDomain by executing a
+     * upstream caller caused a Subject to be bound to the current thread by
+     * executing a
      * {@link javax.security.auth.Subject#doAs(Subject, java.security.PrivilegedAction)}
+     * or {@link javax.security.auth.Subject#callAs(Subject, java.util.concurrent.Callable)}
      * operation.
      * </p>
      * <p>
-     * If a SubjectDomainCombiner exists, determining group membership is
+     * If such a Subject exists, determining group membership is
      * simple: just iterate through the Subject&#8217;s Principal set and look for all
      * Principals of type {@link org.apache.wiki.auth.GroupPrincipal}. If the
      * name of any Principal matches the value of the implied Permission&#8217;s
@@ -477,15 +473,15 @@ public final class GroupPermission extends Permission implements Serializable
             return false;
         }
 
-        // For the current thread, retrieve the SubjectDomainCombiner
-        // (if one was used to create current AccessControlContext )
-        final AccessControlContext acc = AccessController.getContext();
-        final DomainCombiner dc = acc.getDomainCombiner();
-        if ( dc != null && dc instanceof SubjectDomainCombiner )
+        // Retrieve the Subject bound to the current thread by Subject.doAs/callAs.
+        // Subject.current() covers all JVMs >= 18: before JDK 23 it resolves the Subject
+        // from the AccessControlContext's SubjectDomainCombiner internally, since JDK 23
+        // (Security Manager removal, JEP 486) from the scoped value bound by doAs/callAs.
+        final Subject subject = Subject.current();
+        if ( subject != null )
         {
             // <member> implies permission if subject possesses
             // GroupPrincipal with same name as target
-            final Subject subject = ( (SubjectDomainCombiner) dc ).getSubject();
             final Set<GroupPrincipal> principals = subject.getPrincipals( GroupPrincipal.class );
             return principals.stream().anyMatch(principal -> principal.getName().equals(gp.m_group));
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
@@ -115,7 +115,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
 	 * {@link #ensureCreationDateProperties(Page, Properties)} for how it is applied.
 	 */
 	public static final String RESTORE_CREATION_DATES_FILE = "restore-creation-dates.properties";
-	private CachedProperties m_cachedProperties;
+	private volatile CachedProperties m_cachedProperties;
 
 	/**
 	 * {@inheritDoc}
@@ -1018,9 +1018,9 @@ public class VersioningFileProvider extends AbstractFileProvider {
 	 * gain over simply keeping the last one requested.
 	 */
 	private static class CachedProperties {
-		String m_page;
-		Properties m_props;
-		long m_lastModified;
+		final String m_page;
+		final Properties m_props;
+		final long m_lastModified;
 
 		/**
 		 * Because a Constructor is inherently synchronised, there is no need to synchronise the arguments.

--- a/jspwiki-multiwiki/src/main/java/org/apache/wiki/SubWikiInit.java
+++ b/jspwiki-multiwiki/src/main/java/org/apache/wiki/SubWikiInit.java
@@ -27,7 +27,8 @@ public class SubWikiInit {
 		assert folders != null;
 		Collection<File> filteredFolders = Arrays.stream(folders).filter(file ->
 				file.isDirectory()
-						&& !file.getAbsolutePath().equals(".git")
+						// skips .git and any other hidden directory, these are never sub-wikis
+						&& !file.getName().startsWith(".")
 						&& !file.getAbsolutePath().equals(m_pageDirectory)
 						&& !file.getName().equals("OLD")
 						&& !file.getParentFile().getName().equals("OLD")

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputTimestamp>2026-03-21T15:16:08Z</project.build.outputTimestamp> <!-- will be changed by release plugin during releases -->
-    <jdk.version>17</jdk.version>
+    <jdk.version>21</jdk.version>
     <jdk.javadoc.doclet.version>2.2.3</jdk.javadoc.doclet.version>
     <maven.version>3.5</maven.version>
 
@@ -79,7 +79,7 @@
     <jrcs-diff.version>0.4.2</jrcs-diff.version>
     <junit.version>6.0.1</junit.version>
     <logback.version>1.5.19</logback.version>
-    <lucene.version>9.12.2</lucene.version>
+    <lucene.version>10.4.0</lucene.version>
     <mockito.version>5.20.0</mockito.version>
     <nekohtml.version>2.1.3</nekohtml.version>
     <oro.version>2.0.8</oro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <junit.version>6.0.1</junit.version>
     <logback.version>1.5.19</logback.version>
     <lucene.version>10.4.0</lucene.version>
-    <mockito.version>5.20.0</mockito.version>
+    <mockito.version>5.23.0</mockito.version> <!-- 5.23.0 -> byte-buddy 1.17.x, Java-25-fähig -->
     <nekohtml.version>2.1.3</nekohtml.version>
     <oro.version>2.0.8</oro.version>
     <rome.version>2.1.0</rome.version>


### PR DESCRIPTION
Fixes the pre-existing `DefaultPluginManagerTest.testParserPlugin` failure on `knowwe-3.0` (`ProviderException: Page already exists (case insensitive): Testpage`). Currently stacked on `port/master-catchup` (#48) — happy to rebase it directly onto `knowwe-3.0` if you'd rather land it first.

Ehcache returns an *existing* `CacheManager` when the configured name is already in use. Naming it after the application name alone therefore isolates nothing between engines that share that name — and every `TestEngine` reports `JSPWiki`. So all engines in the surefire JVM shared one `CACHE_PAGES`, and since `CachingProvider.getAllPages()` enumerates that cache's keys once `allRequested` is set, it reported pages belonging to other engines. `SaveWikiPageTask`'s guard reads a key-exact `pageExists()` (`Testpage` → miss → real provider → absent), then `checkDuplicatePagesCaseSensitive()` walks `getAllPages()` and matches the phantom `TestPage` case-insensitively.

Confirmed by a diagnostic run: the failing engine's own page directory was empty, while `getAllPages()` returned `[Test Page, TestPage, Test_Page, ThisPage, ThisPage2]` — exactly `InsertPageTest`'s fixture, the class that runs immediately before it in CI order. Order-dependence is why the same tree flipped green → red as the runner image drifted.

**Cost, measured** (jspwiki-main, 925 tests, local): wall time 86.2 s → 88.7 s (+2.8%), peak RSS 1.307 GB → 1.405 GB (+98 MB). Production is unaffected — one engine per webapp means one CacheManager either way.

Checked and clear: no cache declares `overflowToDisk`/`diskPersistent`, so the shared `<diskStore>` path cannot collide; `<ehcache>` declares no `name`, so this block is live rather than dead; `EhcacheCachingManagerTest` only calls `initialize(null, …)` and keeps the singleton path.
