### PR TITLE
Ignore release-plugin and JRebel working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ nb-configuration.xml
 .checkstyle
 **/node_modules/*
 .vscode
+
+# maven-release-plugin / versions-maven-plugin working files
+pom.xml.tag
+pom.xml.next
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+
+# JRebel descriptors are generated per developer
+rebel.xml


### PR DESCRIPTION
Closes the `.gitignore` gap found by the oversight audit — but only the part that this line's tooling actually produces.

The fork's `.gitignore` has 12 entries the 3.0 base lacks. Normalising for trailing slashes and comments, and checking each against what is configured here:

**Added (6)** — `maven-release-plugin` *is* configured in the root pom, and `versions:set` needs no configuration to be run, so these appear next to every module's pom the first time someone cuts a release or bumps coordinates: `pom.xml.tag`, `pom.xml.next`, `pom.xml.releaseBackup`, `pom.xml.versionsBackup`, `release.properties`. Plus `rebel.xml`, which completes D7 — the descriptors were removed from the tree as per-developer files, so they should not be re-committable.

**Deliberately not added (6):**
- `dependency-reduced-pom.xml` — maven-shade-plugin, not used here
- `buildNumber.properties` — buildnumber-maven-plugin, not used here
- `.mvn/timing.properties` — no `.mvn` directory on this line
- `overlays/` — referenced by nothing in the reactor; appears to be a leftover from the fork's older layout
- `*.iml` — already covered by the base's `**/*.iml`
- `*.class` — everything compiles under `target/`, which is already ignored

Independent of #48 and #52.
