### PR TITLE
Isolate each engine's caches from other engines in the same JVM

### DIFF
--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
@@ -74,11 +74,12 @@ public class EhcacheCachingManager implements CachingManager, Initializable {
 			final URL location = this.getClass().getResource(confLocation);
 			LOG.info("Reading ehcache configuration file from classpath on /{}", location);
 			if (engine != null) {
-				// Distinct engines get distinct CacheManagers, named by application name, so their
-				// caches do not collide (required for the multi-wiki / multi-instance case).
+				// One CacheManager per engine instance: ehcache hands back an existing CacheManager when
+				// the configured name is already in use, so the name must identify the engine, not just
+				// the application.
 				final Configuration configuration = ConfigurationFactory.parseConfiguration(location);
 				if (configuration.getName() == null) {
-					configuration.name(engine.getApplicationName());
+					configuration.name(engine.getApplicationName() + "-" + System.identityHashCode(engine));
 				}
 				cacheManager = CacheManager.newInstance(configuration);
 			}


### PR DESCRIPTION
Fixes the pre-existing `DefaultPluginManagerTest.testParserPlugin` failure on `knowwe-3.0` (`ProviderException: Page already exists (case insensitive): Testpage`). Lands directly on `knowwe-3.0`, ahead of the catch-up in #48, since it fixes a break that predates it.

Ehcache returns an *existing* `CacheManager` when the configured name is already in use. Naming it after the application name alone therefore isolates nothing between engines that share that name — and every `TestEngine` reports `JSPWiki`. So all engines in the surefire JVM shared one `CACHE_PAGES`, and since `CachingProvider.getAllPages()` enumerates that cache's keys once `allRequested` is set, it reported pages belonging to other engines. `SaveWikiPageTask`'s guard reads a key-exact `pageExists()` (`Testpage` → miss → real provider → absent), then `checkDuplicatePagesCaseSensitive()` walks `getAllPages()` and matches the phantom `TestPage` case-insensitively.

Confirmed by a diagnostic run: the failing engine's own page directory was empty, while `getAllPages()` returned `[Test Page, TestPage, Test_Page, ThisPage, ThisPage2]` — exactly `InsertPageTest`'s fixture, the class that runs immediately before it in CI order. Order-dependence is why the same tree flipped green → red as the runner image drifted.

**Cost, measured** (jspwiki-main, 925 tests, local): wall time 86.2 s → 88.7 s (+2.8%), peak RSS 1.307 GB → 1.405 GB (+98 MB). Production is unaffected — one engine per webapp means one CacheManager either way.

Checked and clear: no cache declares `overflowToDisk`/`diskPersistent`, so the shared `<diskStore>` path cannot collide; `<ehcache>` declares no `name`, so this block is live rather than dead; `EhcacheCachingManagerTest` only calls `initialize(null, …)` and keeps the singleton path.
